### PR TITLE
[Sync] [Enhancement] Simplify execution logic in run.py; use finally to clean up temp files

### DIFF
--- a/opencompass/runners/dlc.py
+++ b/opencompass/runners/dlc.py
@@ -86,65 +86,70 @@ class DLCRunner(BaseRunner):
         # Dump task config to file
         mmengine.mkdir_or_exist('tmp/')
         param_file = f'tmp/{os.getpid()}_params.py'
-        task_cfg.dump(param_file)
+        try:
+            task_cfg.dump(param_file)
 
-        # Build up DLC command
-        pwd = os.getcwd()
-        shell_cmd = (f'source {self.aliyun_cfg["bashrc_path"]}; '
-                     f'conda activate {self.aliyun_cfg["conda_env_name"]}; '
-                     f'cd {pwd}; '
-                     '{task_cmd}')
+            # Build up DLC command
+            pwd = os.getcwd()
+            shell_cmd = (
+                f'source {self.aliyun_cfg["bashrc_path"]}; '
+                f'conda activate {self.aliyun_cfg["conda_env_name"]}; '
+                f'cd {pwd}; '
+                '{task_cmd}')
 
-        tmpl = ('dlc create job'
-                f" --command '{shell_cmd}'"
-                f' --name {task_name[:512]}'
-                ' --kind BatchJob'
-                f" -c {self.aliyun_cfg['dlc_config_path']}"
-                f" --workspace_id {self.aliyun_cfg['workspace_id']}"
-                ' --worker_count 1'
-                f' --worker_cpu {max(num_gpus * 6, 8)}'
-                f' --worker_gpu {num_gpus}'
-                f' --worker_memory {max(num_gpus * 32, 48)}'
-                f" --worker_image {self.aliyun_cfg['worker_image']}"
-                ' --interactive')
-        get_cmd = partial(task.get_command, cfg_path=param_file, template=tmpl)
-        cmd = get_cmd()
+            tmpl = ('dlc create job'
+                    f" --command '{shell_cmd}'"
+                    f' --name {task_name[:512]}'
+                    ' --kind BatchJob'
+                    f" -c {self.aliyun_cfg['dlc_config_path']}"
+                    f" --workspace_id {self.aliyun_cfg['workspace_id']}"
+                    ' --worker_count 1'
+                    f' --worker_cpu {max(num_gpus * 6, 8)}'
+                    f' --worker_gpu {num_gpus}'
+                    f' --worker_memory {max(num_gpus * 32, 48)}'
+                    f" --worker_image {self.aliyun_cfg['worker_image']}"
+                    ' --interactive')
+            get_cmd = partial(task.get_command,
+                              cfg_path=param_file,
+                              template=tmpl)
+            cmd = get_cmd()
 
-        logger = get_logger()
-        logger.debug(f'Running command: {cmd}')
+            logger = get_logger()
+            logger.debug(f'Running command: {cmd}')
 
-        # Run command with retry
-        if self.debug:
-            stdout = None
-        else:
-            out_path = task.get_log_path(file_extension='out')
-            mmengine.mkdir_or_exist(osp.split(out_path)[0])
-            stdout = open(out_path, 'w', encoding='utf-8')
+            # Run command with retry
+            if self.debug:
+                stdout = None
+            else:
+                out_path = task.get_log_path(file_extension='out')
+                mmengine.mkdir_or_exist(osp.split(out_path)[0])
+                stdout = open(out_path, 'w', encoding='utf-8')
 
-        if random_sleep:
-            time.sleep(random.randint(0, 10))
-        result = subprocess.run(cmd,
-                                shell=True,
-                                text=True,
-                                stdout=stdout,
-                                stderr=stdout)
-
-        retry = self.retry
-        output_paths = task.get_output_paths()
-        while self._job_failed(result.returncode, output_paths) and retry > 0:
-            retry -= 1
             if random_sleep:
                 time.sleep(random.randint(0, 10))
-            # Re-generate command to refresh ports.
-            cmd = get_cmd()
             result = subprocess.run(cmd,
                                     shell=True,
                                     text=True,
                                     stdout=stdout,
                                     stderr=stdout)
 
-        # Clean up
-        os.remove(param_file)
+            retry = self.retry
+            output_paths = task.get_output_paths()
+            while self._job_failed(result.returncode,
+                                   output_paths) and retry > 0:
+                retry -= 1
+                if random_sleep:
+                    time.sleep(random.randint(0, 10))
+                # Re-generate command to refresh ports.
+                cmd = get_cmd()
+                result = subprocess.run(cmd,
+                                        shell=True,
+                                        text=True,
+                                        stdout=stdout,
+                                        stderr=stdout)
+        finally:
+            # Clean up
+            os.remove(param_file)
         return task_name, result.returncode
 
     def _job_failed(self, return_code: int, output_paths: List[str]) -> bool:

--- a/opencompass/runners/local.py
+++ b/opencompass/runners/local.py
@@ -62,15 +62,17 @@ class LocalRunner(BaseRunner):
                 # get cmd
                 mmengine.mkdir_or_exist('tmp/')
                 param_file = f'tmp/{os.getpid()}_params.py'
-                task.cfg.dump(param_file)
-                cmd = task.get_command(cfg_path=param_file,
-                                       template='{task_cmd}')
-                # run in subprocess if starts with torchrun etc.
-                if cmd.startswith('python'):
-                    task.run()
-                else:
-                    subprocess.run(cmd, shell=True, text=True)
-                os.remove(param_file)
+                try:
+                    task.cfg.dump(param_file)
+                    cmd = task.get_command(cfg_path=param_file,
+                                           template='{task_cmd}')
+                    # run in subprocess if starts with torchrun etc.
+                    if cmd.startswith('python'):
+                        task.run()
+                    else:
+                        subprocess.run(cmd, shell=True, text=True)
+                finally:
+                    os.remove(param_file)
                 status.append((task_name, 0))
         else:
             import torch
@@ -141,31 +143,34 @@ class LocalRunner(BaseRunner):
         # Dump task config to file
         mmengine.mkdir_or_exist('tmp/')
         param_file = f'tmp/{os.getpid()}_{index}_params.py'
-        task.cfg.dump(param_file)
+        try:
+            task.cfg.dump(param_file)
 
-        # Build up slurm command
-        tmpl = 'CUDA_VISIBLE_DEVICES=' + ','.join(str(i) for i in gpu_ids)
-        tmpl += ' {task_cmd}'
-        get_cmd = partial(task.get_command, cfg_path=param_file, template=tmpl)
-        cmd = get_cmd()
+            # Build up slurm command
+            tmpl = 'CUDA_VISIBLE_DEVICES=' + ','.join(str(i) for i in gpu_ids)
+            tmpl += ' {task_cmd}'
+            get_cmd = partial(task.get_command,
+                              cfg_path=param_file,
+                              template=tmpl)
+            cmd = get_cmd()
 
-        logger = get_logger()
-        logger.debug(f'Running command: {cmd}')
+            logger = get_logger()
+            logger.debug(f'Running command: {cmd}')
 
-        # Run command
-        out_path = task.get_log_path(file_extension='out')
-        mmengine.mkdir_or_exist(osp.split(out_path)[0])
-        stdout = open(out_path, 'w', encoding='utf-8')
+            # Run command
+            out_path = task.get_log_path(file_extension='out')
+            mmengine.mkdir_or_exist(osp.split(out_path)[0])
+            stdout = open(out_path, 'w', encoding='utf-8')
 
-        result = subprocess.run(cmd,
-                                shell=True,
-                                text=True,
-                                stdout=stdout,
-                                stderr=stdout)
+            result = subprocess.run(cmd,
+                                    shell=True,
+                                    text=True,
+                                    stdout=stdout,
+                                    stderr=stdout)
 
-        if result.returncode != 0:
-            logger.warning(f'task {task_name} fail, see\n{out_path}')
-
-        # Clean up
-        os.remove(param_file)
+            if result.returncode != 0:
+                logger.warning(f'task {task_name} fail, see\n{out_path}')
+        finally:
+            # Clean up
+            os.remove(param_file)
         return task_name, result.returncode

--- a/opencompass/runners/slurm.py
+++ b/opencompass/runners/slurm.py
@@ -91,60 +91,64 @@ class SlurmRunner(BaseRunner):
         # Dump task config to file
         mmengine.mkdir_or_exist('tmp/')
         param_file = f'tmp/{os.getpid()}_params.py'
-        task_cfg.dump(param_file)
+        try:
+            task_cfg.dump(param_file)
 
-        # Build up slurm command
-        tmpl = 'srun'
-        if self.partition:
-            tmpl += f' -p {self.partition}'
-        if self.quotatype:
-            tmpl += f' --quotatype={self.quotatype}'
-        if self.qos:
-            tmpl += f' --qos={self.qos}'
-        if num_gpus > 0:
-            tmpl += f' --gres=gpu:{num_gpus}'
-        tmpl += f" -N1 -J '{task_name[:512]}'" + ' {task_cmd}'
-        get_cmd = partial(task.get_command, cfg_path=param_file, template=tmpl)
-        cmd = get_cmd()
+            # Build up slurm command
+            tmpl = 'srun'
+            if self.partition:
+                tmpl += f' -p {self.partition}'
+            if self.quotatype:
+                tmpl += f' --quotatype={self.quotatype}'
+            if self.qos:
+                tmpl += f' --qos={self.qos}'
+            if num_gpus > 0:
+                tmpl += f' --gres=gpu:{num_gpus}'
+            tmpl += f" -N1 -J '{task_name[:512]}'" + ' {task_cmd}'
+            get_cmd = partial(task.get_command,
+                              cfg_path=param_file,
+                              template=tmpl)
+            cmd = get_cmd()
 
-        logger = get_logger()
-        logger.debug(f'Running command: {cmd}')
+            logger = get_logger()
+            logger.debug(f'Running command: {cmd}')
 
-        # Run command with retry
-        if self.debug:
-            stdout = None
-        else:
-            out_path = task.get_log_path(file_extension='out')
-            mmengine.mkdir_or_exist(osp.split(out_path)[0])
-            stdout = open(out_path, 'w', encoding='utf-8')
+            # Run command with retry
+            if self.debug:
+                stdout = None
+            else:
+                out_path = task.get_log_path(file_extension='out')
+                mmengine.mkdir_or_exist(osp.split(out_path)[0])
+                stdout = open(out_path, 'w', encoding='utf-8')
 
-        if random_sleep:
-            time.sleep(random.randint(0, 10))
-        result = subprocess.run(cmd,
-                                shell=True,
-                                text=True,
-                                stdout=stdout,
-                                stderr=stdout)
-
-        retry = self.retry
-        output_paths = task.get_output_paths()
-        while self._job_failed(result.returncode, output_paths) and retry > 0:
-            retry -= 1
             if random_sleep:
                 time.sleep(random.randint(0, 10))
-            # Re-generate command to refresh ports.
-            cmd = get_cmd()
             result = subprocess.run(cmd,
                                     shell=True,
                                     text=True,
                                     stdout=stdout,
                                     stderr=stdout)
 
-        if result.returncode != 0 and not self.debug:
-            logger.warning(f'task {task_name} fail, see\n{out_path}')
+            retry = self.retry
+            output_paths = task.get_output_paths()
+            while self._job_failed(result.returncode,
+                                   output_paths) and retry > 0:
+                retry -= 1
+                if random_sleep:
+                    time.sleep(random.randint(0, 10))
+                # Re-generate command to refresh ports.
+                cmd = get_cmd()
+                result = subprocess.run(cmd,
+                                        shell=True,
+                                        text=True,
+                                        stdout=stdout,
+                                        stderr=stdout)
 
-        # Clean up
-        os.remove(param_file)
+            if result.returncode != 0 and not self.debug:
+                logger.warning(f'task {task_name} fail, see\n{out_path}')
+        finally:
+            # Clean up
+            os.remove(param_file)
         return task_name, result.returncode
 
     def _job_failed(self, return_code: int, output_paths: List[str]) -> bool:

--- a/opencompass/utils/run.py
+++ b/opencompass/utils/run.py
@@ -3,7 +3,9 @@ from typing import List, Union
 import tabulate
 from mmengine.config import Config
 
+from opencompass.partitioners import NaivePartitioner, SizePartitioner
 from opencompass.runners import DLCRunner, LocalRunner, SlurmRunner
+from opencompass.tasks import OpenICLEvalTask, OpenICLInferTask
 from opencompass.utils import get_logger, match_files
 
 
@@ -118,54 +120,61 @@ def exec_mm_infer_runner(tasks, args, cfg):
     runner(tasks)
 
 
-def exec_infer_runner(tasks, args, cfg):
-    """execute infer runner according to args."""
-    if args.slurm:
-        runner = SlurmRunner(dict(type='OpenICLInferTask'),
-                             max_num_workers=args.max_num_workers,
-                             partition=args.partition,
-                             quotatype=args.quotatype,
-                             qos=args.qos,
-                             retry=args.retry,
-                             debug=args.debug,
-                             lark_bot_url=cfg['lark_bot_url'])
-    elif args.dlc:
-        runner = DLCRunner(dict(type='OpenICLInferTask'),
-                           max_num_workers=args.max_num_workers,
-                           aliyun_cfg=Config.fromfile(args.aliyun_cfg),
-                           retry=args.retry,
-                           debug=args.debug,
-                           lark_bot_url=cfg['lark_bot_url'])
-    else:
-        runner = LocalRunner(task=dict(type='OpenICLInferTask'),
-                             max_num_workers=args.max_num_workers,
-                             max_workers_per_gpu=args.max_workers_per_gpu,
-                             debug=args.debug,
-                             lark_bot_url=cfg['lark_bot_url'])
-    runner(tasks)
+def get_config_type(obj) -> str:
+    return f'{obj.__module__}.{obj.__name__}'
 
 
-def exec_eval_runner(tasks, args, cfg):
-    """execute infer runner according to args."""
+def fill_infer_cfg(cfg, args):
+    new_cfg = dict(infer=dict(
+        partitioner=dict(type=get_config_type(SizePartitioner),
+                         max_task_size=args.max_partition_size,
+                         gen_task_coef=args.gen_task_coef),
+        runner=dict(
+            max_num_workers=args.max_num_workers,
+            debug=args.debug,
+            task=dict(type=get_config_type(OpenICLInferTask)),
+            lark_bot_url=cfg['lark_bot_url'],
+        )), )
     if args.slurm:
-        runner = SlurmRunner(dict(type='OpenICLEvalTask'),
-                             max_num_workers=args.max_num_workers,
-                             partition=args.partition,
-                             quotatype=args.quotatype,
-                             qos=args.qos,
-                             retry=args.retry,
-                             debug=args.debug,
-                             lark_bot_url=cfg['lark_bot_url'])
+        new_cfg['infer']['runner']['type'] = get_config_type(SlurmRunner)
+        new_cfg['infer']['runner']['partition'] = args.partition
+        new_cfg['infer']['runner']['quotatype'] = args.quotatype
+        new_cfg['infer']['runner']['qos'] = args.qos
+        new_cfg['infer']['runner']['retry'] = args.retry
     elif args.dlc:
-        runner = DLCRunner(dict(type='OpenICLEvalTask'),
-                           max_num_workers=args.max_num_workers,
-                           aliyun_cfg=Config.fromfile(args.aliyun_cfg),
-                           retry=args.retry,
-                           debug=args.debug,
-                           lark_bot_url=cfg['lark_bot_url'])
+        new_cfg['infer']['runner']['type'] = get_config_type(DLCRunner)
+        new_cfg['infer']['runner']['aliyun_cfg'] = Config.fromfile(
+            args.aliyun_cfg)
+        new_cfg['infer']['runner']['retry'] = args.retry
     else:
-        runner = LocalRunner(task=dict(type='OpenICLEvalTask'),
-                             max_num_workers=args.max_num_workers,
-                             debug=args.debug,
-                             lark_bot_url=cfg['lark_bot_url'])
-    runner(tasks)
+        new_cfg['infer']['runner']['type'] = get_config_type(LocalRunner)
+        new_cfg['infer']['runner'][
+            'max_workers_per_gpu'] = args.max_workers_per_gpu
+    cfg.merge_from_dict(new_cfg)
+
+
+def fill_eval_cfg(cfg, args):
+    new_cfg = dict(
+        eval=dict(partitioner=dict(type=get_config_type(NaivePartitioner)),
+                  runner=dict(
+                      max_num_workers=args.max_num_workers,
+                      debug=args.debug,
+                      task=dict(type=get_config_type(OpenICLEvalTask)),
+                      lark_bot_url=cfg['lark_bot_url'],
+                  )))
+    if args.slurm:
+        new_cfg['eval']['runner']['type'] = get_config_type(SlurmRunner)
+        new_cfg['eval']['runner']['partition'] = args.partition
+        new_cfg['eval']['runner']['quotatype'] = args.quotatype
+        new_cfg['eval']['runner']['qos'] = args.qos
+        new_cfg['eval']['runner']['retry'] = args.retry
+    elif args.dlc:
+        new_cfg['eval']['runner']['type'] = get_config_type(DLCRunner)
+        new_cfg['eval']['runner']['aliyun_cfg'] = Config.fromfile(
+            args.aliyun_cfg)
+        new_cfg['eval']['runner']['retry'] = args.retry
+    else:
+        new_cfg['eval']['runner']['type'] = get_config_type(LocalRunner)
+        new_cfg['eval']['runner'][
+            'max_workers_per_gpu'] = args.max_workers_per_gpu
+    cfg.merge_from_dict(new_cfg)


### PR DESCRIPTION
## Motivation

The former logic in run.py is rather complex when user chooses to specify task parameters from CLI instead of config - it uses "exec_xxx_runner" and makes the entire execution flow diverge from the configuration path. Such an implementation makes it hard for future maintenance and leads to unnecessary code redundancies.

This PR unifies the execution flow and now all the parameter specifications are performed through the modifications on the configuration object. 

Besides, this PR uses `try... finally...` to make sure temporary files created during running can be cleaned even when an exception has been raised (e.g. KeyBoardInterrupt).
