### PR TITLE
feat: add custom summarizer argument in CLI run mode 在CLI启动模式中添加自定义Summarizer参数

### DIFF
--- a/opencompass/utils/run.py
+++ b/opencompass/utils/run.py
@@ -98,8 +98,9 @@ def get_config_from_arg(args) -> Config:
     
     summarizer = None
     if args.summarizer:
-        cfg = Config.fromfile(args.summarizer)
-        print(f"Loading summarizer config from {args.summarizer}")
+        s = match_cfg_file('configs/summarizers/', [args.summarizer])[0]
+        get_logger().info(f'Loading {s[0]}: {s[1]}')
+        cfg = Config.fromfile(s[1])
         summarizer = cfg['summarizer']
 
     return Config(dict(models=models, datasets=datasets, summarizer=summarizer),

--- a/opencompass/utils/run.py
+++ b/opencompass/utils/run.py
@@ -95,7 +95,14 @@ def get_config_from_arg(args) -> Config:
                      pad_token_id=args.pad_token_id,
                      run_cfg=dict(num_gpus=args.num_gpus))
         models.append(model)
-    return Config(dict(models=models, datasets=datasets),
+    
+    summarizer = None
+    if args.summarizer:
+        cfg = Config.fromfile(args.summarizer)
+        print(f"Loading summarizer config from {args.summarizer}")
+        summarizer = cfg['summarizer']
+
+    return Config(dict(models=models, datasets=datasets, summarizer=summarizer),
                   format_python_code=False)
 
 

--- a/opencompass/utils/summarizer.py
+++ b/opencompass/utils/summarizer.py
@@ -36,7 +36,7 @@ class Summarizer:
 
         model_cfgs = self.cfg['models']
         dataset_cfgs = self.cfg['datasets']
-        summarizer_cfg = self.cfg.get('summarizer', {})
+        summarizer_cfg = self.cfg.get('summarizer', {}) or {} # avoid 'summarizer' is in cfg but None
         work_dir = self.cfg['work_dir']
 
         # pick up results

--- a/run.py
+++ b/run.py
@@ -38,9 +38,10 @@ def parse_args():
                         help='Whether or not enable multimodal evaluation',
                         action='store_true',
                         default=False)
-    # Add shortcut parameters (models and datasets)
+    # Add shortcut parameters (models, datasets and summarizer)
     parser.add_argument('--models', nargs='+', help='', default=None)
     parser.add_argument('--datasets', nargs='+', help='', default=None)
+    parser.add_argument('--summarizer', help='', default=None)
     # add general args
     parser.add_argument('--debug',
                         help='Debug mode, in which scheduler will run tasks '


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The new CLI mode is very helpful. But it's lack of custom summarizer argument. This PR solves this. User can use `python run.py --models hf_qwen_7b --datasets smoking_gen --summarizer configs/summarizers/medium.py` to run with custom summarizer. 

## Modification

1. Add --summarizer argument
2. read related config file
3. fix related bug to compatible with command without custom summarizer


## Use cases 

The following cases are tested. `smoking_gen` is a short custom defined dataset to test quickly.

- `python run.py --models hf_qwen_7b --datasets smoking_gen --summarizer configs/summarizers/medium.py`
- `python run.py --models hf_qwen_7b --datasets smoking_gen`

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
