### PR TITLE
support customize config path

### DIFF
--- a/opencompass/utils/run.py
+++ b/opencompass/utils/run.py
@@ -1,3 +1,4 @@
+import os
 from typing import List, Union
 
 import tabulate
@@ -61,7 +62,8 @@ def get_config_from_arg(args) -> Config:
                          'a config file path.')
     datasets = []
     config_base_dir = args.custom_config_dir or 'configs'
-    for dataset in match_cfg_file(f'{config_base_dir}/datasets/', args.datasets):
+    datasets_dir = os.path.join(config_base_dir, 'datasets')
+    for dataset in match_cfg_file(datasets_dir, args.datasets):
         get_logger().info(f'Loading {dataset[0]}: {dataset[1]}')
         cfg = Config.fromfile(dataset[1])
         for k in cfg.keys():
@@ -74,7 +76,8 @@ def get_config_from_arg(args) -> Config:
                          '--datasets.')
     models = []
     if args.models:
-        for model in match_cfg_file(f'{config_base_dir}/models/', args.models):
+        model_dir = os.path.join(config_base_dir, 'models')
+        for model in match_cfg_file(model_dir, args.models):
             get_logger().info(f'Loading {model[0]}: {model[1]}')
             cfg = Config.fromfile(model[1])
             if 'models' not in cfg:
@@ -99,7 +102,8 @@ def get_config_from_arg(args) -> Config:
 
     summarizer = None
     if args.summarizer:
-        s = match_cfg_file('configs/summarizers/', [args.summarizer])[0]
+        summarizers_dir = os.path.join(config_base_dir, 'summarizers')
+        s = match_cfg_file(summarizers_dir, [args.summarizer])[0]
         get_logger().info(f'Loading {s[0]}: {s[1]}')
         cfg = Config.fromfile(s[1])
         summarizer = cfg['summarizer']

--- a/opencompass/utils/run.py
+++ b/opencompass/utils/run.py
@@ -60,7 +60,8 @@ def get_config_from_arg(args) -> Config:
         raise ValueError('You must specify "--datasets" if you do not specify '
                          'a config file path.')
     datasets = []
-    for dataset in match_cfg_file('configs/datasets/', args.datasets):
+    config_base_dir = args.custom_config_dir or 'configs'
+    for dataset in match_cfg_file(f'{config_base_dir}/datasets/', args.datasets):
         get_logger().info(f'Loading {dataset[0]}: {dataset[1]}')
         cfg = Config.fromfile(dataset[1])
         for k in cfg.keys():
@@ -73,7 +74,7 @@ def get_config_from_arg(args) -> Config:
                          '--datasets.')
     models = []
     if args.models:
-        for model in match_cfg_file('configs/models/', args.models):
+        for model in match_cfg_file(f'{config_base_dir}/models/', args.models):
             get_logger().info(f'Loading {model[0]}: {model[1]}')
             cfg = Config.fromfile(model[1])
             if 'models' not in cfg:

--- a/opencompass/utils/run.py
+++ b/opencompass/utils/run.py
@@ -61,8 +61,7 @@ def get_config_from_arg(args) -> Config:
         raise ValueError('You must specify "--datasets" if you do not specify '
                          'a config file path.')
     datasets = []
-    config_base_dir = args.custom_config_dir or 'configs'
-    datasets_dir = os.path.join(config_base_dir, 'datasets')
+    datasets_dir = os.path.join(args.config_dir, 'datasets')
     for dataset in match_cfg_file(datasets_dir, args.datasets):
         get_logger().info(f'Loading {dataset[0]}: {dataset[1]}')
         cfg = Config.fromfile(dataset[1])
@@ -76,7 +75,7 @@ def get_config_from_arg(args) -> Config:
                          '--datasets.')
     models = []
     if args.models:
-        model_dir = os.path.join(config_base_dir, 'models')
+        model_dir = os.path.join(args.config_dir, 'models')
         for model in match_cfg_file(model_dir, args.models):
             get_logger().info(f'Loading {model[0]}: {model[1]}')
             cfg = Config.fromfile(model[1])
@@ -102,7 +101,7 @@ def get_config_from_arg(args) -> Config:
 
     summarizer = None
     if args.summarizer:
-        summarizers_dir = os.path.join(config_base_dir, 'summarizers')
+        summarizers_dir = os.path.join(args.config_dir, 'summarizers')
         s = match_cfg_file(summarizers_dir, [args.summarizer])[0]
         get_logger().info(f'Loading {s[0]}: {s[1]}')
         cfg = Config.fromfile(s[1])

--- a/run.py
+++ b/run.py
@@ -83,6 +83,11 @@ def parse_args():
                         './outputs/default.',
                         default=None,
                         type=str)
+    parser.add_argument('--custom-config-dir',
+                        help='Use the custom config directory instead of config/ to '
+                        'search the configs for datasets and models',
+                        default=None,
+                        type=str)
     parser.add_argument('-l',
                         '--lark',
                         help='Report the running status to lark bot',

--- a/run.py
+++ b/run.py
@@ -83,11 +83,12 @@ def parse_args():
                         './outputs/default.',
                         default=None,
                         type=str)
-    parser.add_argument('--custom-config-dir',
-                        help='Use the custom config directory instead of config/ to '
-                        'search the configs for datasets and models',
-                        default=None,
-                        type=str)
+    parser.add_argument(
+        '--config-dir',
+        default='configs',
+        help='Use the custom config directory instead of config/ to '
+        'search the configs for datasets, models and summarizers',
+        type=str)
     parser.add_argument('-l',
                         '--lark',
                         help='Report the running status to lark bot',


### PR DESCRIPTION
If the config path can be customized, then when other projects introduce opencompass, they can maintain their own datasets/models configuration in their own projects:)