### PR TITLE
[Fix] split if and only if complete eos string shows up

### DIFF
--- a/opencompass/tasks/openicl_eval.py
+++ b/opencompass/tasks/openicl_eval.py
@@ -246,7 +246,7 @@ class OpenICLEvalTask(BaseTask):
         if end_str:
             # TODO: Support calling tokenizer for the accurate eos token
             # and avoid such hardcode
-            end_idx = s.find(end_str[:1], start)
+            end_idx = s.find(end_str, start)
             if end_idx != -1:
                 end = end_idx
 


### PR DESCRIPTION
Some models use `<eoa>` as end of assistant token in SFT, the original implementation causes the evaluation results to be unable to write `<`.




