### PR TITLE
[Fix] Fix summary default

### DIFF
--- a/opencompass/utils/run.py
+++ b/opencompass/utils/run.py
@@ -99,7 +99,7 @@ def get_config_from_arg(args) -> Config:
                      run_cfg=dict(num_gpus=args.num_gpus))
         models.append(model)
 
-    summarizer = None
+    summarizer = {}
     if args.summarizer:
         summarizers_dir = os.path.join(args.config_dir, 'summarizers')
         s = match_cfg_file(summarizers_dir, [args.summarizer])[0]


### PR DESCRIPTION
In case of the following error, where summarizer is set to None

```text
Traceback (most recent call last):
  File "/mnt/hwfile/zhoufengzhe/repos/prs/opencompass/run.py", line 329, in <module>
    main()
  File "/mnt/hwfile/zhoufengzhe/repos/prs/opencompass/run.py", line 322, in main
    summarizer_cfg['type'] = DefaultSummarizer
TypeError: 'NoneType' object does not support item assignment
```