### PR TITLE
[Feature] Support chat style inferencer.

### DIFF
--- a/configs/eval_chat_cibench.py
+++ b/configs/eval_chat_cibench.py
@@ -1,0 +1,82 @@
+from lagent.agents.react import ReActProtocol
+from mmengine.config import read_base
+
+from opencompass.lagent.actions.ipython_interpreter import IPythonInterpreter
+from opencompass.lagent.agents.react import CIReAct
+from opencompass.models.lagent import CodeAgent
+from opencompass.models.openai_api import OpenAI
+from opencompass.partitioners import SizePartitioner
+from opencompass.runners import LocalRunner
+from opencompass.tasks import OpenICLInferTask
+
+with read_base():
+    from .datasets.CIBench.CIBench_gen_eb42f9 import \
+        cibench_datasets as datasets
+
+FORCE_STOP_PROMPT_EN = """You should directly give results based on history information."""
+
+FEWSHOT_INSTRUCTION = """\
+You are an assistant who can utilize external tools.
+{tool_description}
+To use a tool, please response with the following format:
+```
+{thought} Think what you need to solve, do you need to use tools?
+{action} The tool name, should be one of [{action_names}].
+{action_input} The input to the tool that you want to use.
+```
+The tool will give you response after your response using the following format:
+```
+{response} the results after call the tool.
+```
+Therefore DO NOT generate tool response by yourself.
+
+Also please follow the guidelines:
+1. Always use code interpreter to solve the problem.
+2. The generated codes should always in a markdown code block format.
+3. The generated codes will be executed in an ipython manner and the results will be cached.
+4. Your responded code should always be simple and only solves the problem in current step.
+
+Begin!
+"""
+
+IPYTHON_INTERPRETER_DESCRIPTION = '''\
+It can run Python code in a manner as jupyter notebook. The code must be a valid code that contains only python method.'''
+
+models = [
+    dict(
+        abbr='gpt-3.5-code',
+        type=CodeAgent,
+        agent_type=CIReAct,
+        max_turn=3,
+        llm=dict(
+            type=OpenAI,
+            path='gpt-3.5-turbo',
+            key='ENV',
+            query_per_second=1,
+            max_seq_len=4096,
+        ),
+        actions=[
+            dict(type=IPythonInterpreter,
+                 description=IPYTHON_INTERPRETER_DESCRIPTION)
+        ],
+        protocol=dict(
+            type=ReActProtocol,
+            call_protocol=FEWSHOT_INSTRUCTION,
+            force_stop=FORCE_STOP_PROMPT_EN,
+            finish=dict(role='FINISH', begin='Final Answer:', end='\n'),
+        ),
+        batch_size=1,
+    ),
+]
+
+for dataset in datasets:
+    # Evaluate on every assistant response
+    dataset['infer_cfg']['inferencer']['infer_mode'] = 'every'
+
+infer = dict(
+    partitioner=dict(type=SizePartitioner, max_task_size=1000),
+    runner=dict(
+        type=LocalRunner,
+        max_num_workers=16,
+        task=dict(type=OpenICLInferTask)),
+)

--- a/configs/eval_chat_last.py
+++ b/configs/eval_chat_last.py
@@ -1,0 +1,35 @@
+from mmengine.config import read_base
+
+from opencompass.models.openai_api import OpenAI
+from opencompass.openicl import ChatInferencer
+from opencompass.partitioners import SizePartitioner
+from opencompass.runners import LocalRunner
+from opencompass.tasks import OpenICLInferTask
+
+with read_base():
+    from .datasets.gsm8k.gsm8k_gen_1d7fe4 import gsm8k_datasets as datasets
+
+models = [
+    dict(
+        abbr='gpt-3.5',
+        type=OpenAI,
+        path='gpt-3.5-turbo',
+        key='ENV',
+        max_out_len=100,
+        max_seq_len=2048,
+        batch_size=16,
+        run_cfg=dict(num_gpus=1, num_procs=1),
+    )
+]
+
+for dataset in datasets:
+    # Use ChatInferencer instead of GenInferencer
+    dataset['infer_cfg']['inferencer'] = dict(type=ChatInferencer)
+
+infer = dict(
+    partitioner=dict(type=SizePartitioner, max_task_size=1000),
+    runner=dict(
+        type=LocalRunner,
+        max_num_workers=16,
+        task=dict(type=OpenICLInferTask)),
+)

--- a/opencompass/datasets/cibench.py
+++ b/opencompass/datasets/cibench.py
@@ -43,7 +43,10 @@ def load_experiment(file: str) -> dict:
                     outputs.append(None)
     return dict(
         experiment=file,
-        questions=questions,
+        questions=sum(([
+            dict(role='user', content=question),
+            dict(role='assistant', content=output)
+        ] for question, output in zip(questions, outputs)), []),
         references=dict(outputs=outputs, tags=tags, experiment=file),
     )
 

--- a/opencompass/lagent/actions/ipython_interpreter.py
+++ b/opencompass/lagent/actions/ipython_interpreter.py
@@ -72,6 +72,8 @@ class IPythonInterpreter(BaseAction):
             user_data_dir = f"import os\nos.chdir('{user_data_dir}')"
         self.user_data_dir = user_data_dir
         self._initialized = False
+        if not os.path.exists(WORK_DIR):
+            os.mkdir(WORK_DIR)
 
     @staticmethod
     def start_kernel():

--- a/opencompass/lagent/agents/react.py
+++ b/opencompass/lagent/agents/react.py
@@ -1,131 +1,5 @@
-import re
-from typing import Union
-
-from lagent.actions import ActionExecutor
-from lagent.agents.base_agent import BaseAgent
-from lagent.agents.react import ReActProtocol
-from lagent.llms.base_api import BaseAPIModel
-from lagent.llms.base_llm import BaseModel
+from lagent.agents.react import ReAct
 from lagent.schema import ActionReturn, ActionStatusCode, AgentReturn
-
-
-class ReAct(BaseAgent):
-    """An implementation of ReAct (https://arxiv.org/abs/2210.03629)
-
-    Args:
-        llm (BaseModel or BaseAPIModel): a LLM service which can chat
-            and act as backend.
-        action_executor (ActionExecutor): an action executor to manage
-            all actions and their response.
-        protocol (ReActProtocol): a wrapper to generate prompt and
-            parse the response from LLM / actions.
-        max_turn (int): the maximum number of trails for LLM to generate
-            plans that can be successfully parsed by ReWOO protocol.
-    """
-
-    def __init__(self,
-                 llm: Union[BaseModel, BaseAPIModel],
-                 action_executor: ActionExecutor,
-                 protocol: ReActProtocol = ReActProtocol(),
-                 max_turn: int = 2) -> None:
-        self.max_turn = max_turn
-        super().__init__(llm=llm,
-                         action_executor=action_executor,
-                         protocol=protocol)
-
-    def reset(self):
-        """Reset history."""
-        self._session_history = []
-
-    def opencompass_adapter(self, prompt):
-        # adapter for prompt parsing
-        if isinstance(prompt, list):
-            system_prompt = []
-            merged_prompt = []
-            for p in prompt:
-                tmp_p = p.copy()
-                if 'content' in tmp_p:
-                    tmp_p['prompt'] = tmp_p.pop('content')
-                if 'role' in tmp_p:
-                    if tmp_p['role'] == 'system':
-                        # skip system prompt
-                        system_prompt.append(tmp_p['prompt'])
-                        continue
-                    # no system for meta template temperaily
-                    if tmp_p['role'] == 'assistant':
-                        tmp_p['role'] = 'BOT'
-                    if tmp_p['role'] == 'user':
-                        # merge previous system prompt to user
-                        system_str = ''.join(system_prompt)
-                        tmp_p['prompt'] = system_str + tmp_p['prompt']
-                        tmp_p['role'] = 'HUMAN'
-                        system_prompt = []
-                merged_prompt.append(tmp_p)
-
-            # merge if system still exists
-            if system_prompt:
-                if 'role' in merged_prompt[-1]:
-                    if merged_prompt[-1]['role'] == 'HUMAN':
-                        # append to the final human prompt
-                        merged_prompt[-1]['prompt'] += ''.join(system_prompt)
-                    else:
-                        # create a human prompt behind
-                        merged_prompt.append(
-                            dict(role='HUMAN', prompt=''.join(system_prompt)))
-
-        from opencompass.utils.prompt import PromptList
-        new_prompt = PromptList()
-        # adapter for meta template
-        new_prompt.append(dict(section='round', pos='begin'))
-        new_prompt.extend(merged_prompt)
-        new_prompt.append(dict(section='round', pos='end'))
-
-        return new_prompt
-
-    def chat(self, message: str) -> AgentReturn:
-        self._inner_history = []
-        self._inner_history.append(dict(role='user', content=message))
-        agent_return = AgentReturn()
-        force_stop = False
-        default_response = '对不起，我无法回答你的问题'
-        for turn in range(self.max_turn):
-            prompt = self._protocol.format(
-                chat_history=self.session_history,
-                inner_step=self._inner_history,
-                action_executor=self._action_executor,
-                force_stop=force_stop)
-            prompt = self.opencompass_adapter(prompt)
-            # allow single generation
-            response = self._llm.generate_from_template([prompt], 512)[0]
-            self._inner_history.append(dict(role='assistant',
-                                            content=response))
-            thought, action, action_input = self._protocol.parse(
-                response, self._action_executor)
-
-            # TODO: hard code here
-            action_input = re.sub('<eoa>', '', action_input)
-
-            if 'tensorflow' in action_input:
-                # skip tensorflow currently
-                break
-            action_return: ActionReturn = self._action_executor(
-                action, action_input)
-            action_return.thought = thought
-            agent_return.actions.append(action_return)
-            if action_return.type == self._action_executor.finish_action.name:
-                agent_return.response = action_return.result['text']
-                return agent_return
-            self._inner_history.append(
-                dict(role='system',
-                     content=self._protocol.format_response(action_return)))
-            if turn == self.max_turn - 1:
-                force_stop = True
-        agent_return.response = default_response
-        # only append the user and final response
-        self._session_history.append(dict(role='user', content=message))
-        self._session_history.append(
-            dict(role='assistant', content=agent_return.response))
-        return agent_return
 
 
 class CIReAct(ReAct):
@@ -165,9 +39,7 @@ class CIReAct(ReAct):
                 inner_step=self._inner_history,
                 action_executor=self._action_executor,
                 force_stop=force_stop)
-            prompt = self.opencompass_adapter(prompt)
-            # allow single generation
-            response = self._llm.generate_from_template([prompt], 512)[0]
+            response = self._llm.generate_from_template(prompt, 512)
             self._inner_history.append(dict(role='assistant',
                                             content=response))
             thought, action, action_input = self._protocol.parse(
@@ -179,7 +51,7 @@ class CIReAct(ReAct):
             if action_return.state == ActionStatusCode.SUCCESS:
                 # if success, stash model response and system response
                 self._session_history.append(
-                    dict(role='assistant', content=action_return.args['text']))
+                    dict(role='assistant', content=response))
                 self._session_history.append(
                     dict(
                         role='system',

--- a/opencompass/openicl/icl_inferencer/__init__.py
+++ b/opencompass/openicl/icl_inferencer/__init__.py
@@ -1,6 +1,7 @@
 from .icl_agent_inferencer import AgentInferencer  # noqa
 from .icl_attack_inferencer import AttackInferencer  # noqa
 from .icl_base_inferencer import BaseInferencer  # noqa
+from .icl_chat_inferencer import ChatInferencer  # noqa
 from .icl_clp_inferencer import CLPInferencer  # noqa
 from .icl_gen_inferencer import GenInferencer  # noqa
 from .icl_ppl_inferencer import PPLInferencer  # noqa

--- a/opencompass/openicl/icl_inferencer/icl_chat_inferencer.py
+++ b/opencompass/openicl/icl_inferencer/icl_chat_inferencer.py
@@ -1,0 +1,368 @@
+"""Chat Inferencer."""
+import os
+import os.path as osp
+from typing import List, Optional, Union
+
+import mmengine
+from mmengine import is_list_of
+from tqdm import tqdm
+
+from opencompass.models import APITemplateParser as _APITemplateParser
+from opencompass.models import BaseModel
+from opencompass.models import LMTemplateParser as _LMTemplateParser
+from opencompass.registry import ICL_INFERENCERS
+from opencompass.utils.prompt import PromptList
+
+from ..icl_prompt_template import PromptTemplate
+from ..icl_retriever import BaseRetriever
+from ..utils.logging import get_logger
+from .icl_base_inferencer import BaseInferencer, dump_results_dict
+
+logger = get_logger(__name__)
+
+
+def promptlist_to_openai(prompt: Union[str, PromptList]):
+    output = []
+    if isinstance(prompt, str):
+        return [dict(role='user', content=prompt)]
+
+    for item in prompt:
+        if 'section' in item:
+            continue
+        if isinstance(item, str) and item:
+            output.append(dict(role='user', content=item))
+        elif item['role'] == 'SYSTEM':
+            output.append(dict(role='system', content=item['prompt']))
+        elif item['role'] == 'HUMAN':
+            output.append(dict(role='user', content=item['prompt']))
+        elif item['role'] == 'BOT':
+            output.append(dict(role='assistant', content=item['prompt']))
+    return output
+
+
+class LMTemplateParser:
+    """LMTemplateParser accepts OpenAI format dialog inputs."""
+
+    def __init__(self, meta_template: Optional[dict] = None):
+        self.meta_template = meta_template
+        self.roles = {}
+        role_mapping = {
+            'SYSTEM': 'system',
+            'HUMAN': 'user',
+            'BOT': 'assistant',
+        }
+        if meta_template:
+            for item in meta_template.get('round', []):
+                role = role_mapping.get(item['role'], item['role'])
+                self.roles[role] = item.copy()
+            for item in meta_template.get('reserved_roles', []):
+                role = role_mapping.get(item['role'], item['role'])
+                self.roles[role] = item.copy()
+
+    def parse_template(self, chat: List[dict], mode='gen') -> str:
+        if is_list_of(chat, list):
+            # Handle batch inputs
+            return [self.parse_template(item) for item in chat]
+
+        assert is_list_of(chat, dict)
+        prompt = ''
+        if self.roles:
+            for dialog in chat:
+                role_cfg = self.roles.get(dialog['role'])
+                prompt += role_cfg['begin']
+                prompt += (dialog.get('content') or '')
+                prompt += role_cfg['end']
+            prompt += self.roles['assistant']['begin']
+        else:
+            # in case the model does not have any meta template
+            last_sep = ''
+            for item in dialog:
+                prompt += last_sep + (item.get('content') or '')
+                last_sep = '\n'
+        return prompt
+
+
+class APITemplateParser:
+    """APITemplateParser accepts OpenAI format dialog inputs."""
+
+    def __init__(self, meta_template: Optional[dict] = None):
+        self.meta_template = meta_template
+        self.roles = {}
+        role_mapping = {
+            'SYSTEM': 'system',
+            'HUMAN': 'user',
+            'BOT': 'assistant',
+        }
+        if meta_template:
+            for item in meta_template.get('round', []):
+                role = role_mapping.get(item['role'], item['role'])
+                self.roles[role] = item.copy()
+            for item in meta_template.get('reserved_roles', []):
+                role = role_mapping.get(item['role'], item['role'])
+                self.roles[role] = item.copy()
+        else:
+            self.roles = dict(
+                system=dict(api_role='SYSTEM'),
+                user=dict(api_role='HUMAN'),
+                assistant=dict(api_role='BOT', generate=True),
+            )
+
+    def parse_template(self, chat: List[dict], mode='gen') -> str:
+        if is_list_of(chat, list):
+            # Handle batch inputs
+            return [self.parse_template(item) for item in chat]
+
+        assert is_list_of(chat, dict)
+        prompt = []
+        for dialog in chat:
+            if dialog['role'] in self.roles:
+                role = self.roles[dialog['role']]['api_role']
+            else:
+                role = dialog['role']
+            prompt.append(dict(role=role, prompt=dialog.get('content') or ''))
+        return PromptList(prompt)
+
+
+class ChatOutputHandler:
+
+    def __init__(self) -> None:
+        self.results_dict = {}
+
+    def write_to_json(self, save_dir: str, filename: str):
+        """Dump the result to a json file."""
+        dump_results_dict(self.results_dict, osp.join(save_dir, filename))
+
+    def save_results(self,
+                     origin_prompt: list,
+                     prediction: str,
+                     idx: int,
+                     gold: str = None):
+        result_dict = {}
+        if gold:
+            result_dict['gold'] = gold
+        result_dict.update({
+            'prediction': prediction,
+            'origin_prompt': origin_prompt,
+        })
+        self.results_dict[str(idx)] = result_dict
+
+    def save_multiround_results(self,
+                                origin_prompt: list,
+                                prediction: str,
+                                idx: int,
+                                gold: str = None):
+        result_dict = self.results_dict.get(str(idx), {
+            'gold': [],
+            'prediction': [],
+            'origin_prompt': [],
+        })
+        result_dict['gold'].append(gold)
+        result_dict['prediction'].append(prediction)
+        result_dict['origin_prompt'].append(origin_prompt)
+        self.results_dict[str(idx)] = result_dict
+
+
+@ICL_INFERENCERS.register_module()
+class ChatInferencer(BaseInferencer):
+    HandlerType = ChatOutputHandler
+
+    def __init__(
+            self,
+            model,
+            output_json_filepath: Optional[str] = './icl_inference_output',
+            output_json_filename: Optional[str] = 'predictions',
+            save_every: Optional[int] = 1,
+            infer_mode: str = 'last',
+            **kwargs) -> None:
+        super().__init__(
+            model=model,
+            output_json_filename=output_json_filename,
+            output_json_filepath=output_json_filepath,
+            **kwargs,
+        )
+        assert infer_mode in ['last', 'every', 'every_with_gt']
+        self.infer_mode = infer_mode
+        self.model: BaseModel
+        self._set_meta_template(self.model)
+
+        if self.model.is_api and save_every is None:
+            save_every = 1
+        self.save_every = save_every
+
+    def _set_meta_template(self, model):
+        origin = model.template_parser
+        if isinstance(origin, _APITemplateParser):
+            model.template_parser = APITemplateParser(origin.meta_template)
+        if isinstance(origin, _LMTemplateParser):
+            model.template_parser = LMTemplateParser(origin.meta_template)
+
+    def inference(self,
+                  retriever: BaseRetriever,
+                  ice_template: Optional[PromptTemplate] = None,
+                  prompt_template: Optional[PromptTemplate] = None,
+                  output_json_filepath: Optional[str] = None,
+                  output_json_filename: Optional[str] = None) -> dict:
+        # 1. Preparation for output logs
+        output_handler = self.HandlerType()
+
+        if output_json_filepath is None:
+            output_json_filepath = self.output_json_filepath
+        if output_json_filename is None:
+            output_json_filename = self.output_json_filename
+
+        # 2. Get results of retrieval process
+        ice_idx_list = retriever.retrieve()
+
+        # 3. Generate prompts for testing input
+        chat_list = self.get_chat_list(
+            ice_idx_list,
+            retriever,
+            prompt_template=prompt_template,
+        )
+
+        # Create tmp json file for saving intermediate results and future
+        # resuming
+        index = 0
+        tmp_json_filepath = os.path.join(output_json_filepath,
+                                         'tmp_' + output_json_filename)
+        if osp.exists(tmp_json_filepath):
+            # TODO: move resume to output handler
+            tmp_result_dict = mmengine.load(tmp_json_filepath)
+            output_handler.results_dict = tmp_result_dict
+            index = len(tmp_result_dict)
+
+        # 4. Wrap prompts with Dataloader
+        dataloader = self.get_dataloader(chat_list[index:], batch_size=1)
+
+        # 5. Inference for prompts in each batch
+        logger.info('Starting inference process...')
+        for datum in tqdm(dataloader, disable=not self.is_main_process):
+            chat = datum[0]
+
+            if self.infer_mode == 'last':
+                self.infer_last(chat, index, output_handler)
+            elif self.infer_mode == 'every':
+                self.infer_every(chat, index, output_handler)
+            elif self.infer_mode == 'every_with_gt':
+                self.infer_every_with_gt(chat, index, output_handler)
+            index += 1
+
+            # Save intermediate results
+            if (self.save_every is not None and index % self.save_every == 0
+                    and self.is_main_process):
+                output_handler.write_to_json(output_json_filepath,
+                                             'tmp_' + output_json_filename)
+
+        # 4. Output
+        if self.is_main_process:
+            os.makedirs(output_json_filepath, exist_ok=True)
+            output_handler.write_to_json(output_json_filepath,
+                                         output_json_filename)
+            if osp.exists(tmp_json_filepath):
+                os.remove(tmp_json_filepath)
+
+        return output_handler.results_dict
+
+    def get_chat_list(self,
+                      ice_idx_list: List[List[int]],
+                      retriever: BaseRetriever,
+                      prompt_template: Optional[PromptTemplate] = None):
+        prompt_list = []
+        input_columns = retriever.dataset_reader.input_columns
+        output_column = retriever.dataset_reader.output_column
+
+        def chat_from_entry(entry):
+            if prompt_template is None and len(input_columns) == 1:
+                # Directly use the input column as the user input
+                user = entry.get(input_columns[0])
+                assistant = entry.get(output_column, '')
+                return [
+                    dict(role='user', content=user),
+                    dict(role='assistant', content=assistant),
+                ]
+            elif prompt_template is not None:
+                # Use prompt template to generate chat history
+                chat = promptlist_to_openai(
+                    prompt_template.generate_item(entry))
+                gold = entry.get(output_column, '')
+                if chat[-1]['role'] != 'assistant':
+                    chat.append(dict(role='assistant', content=gold))
+                return chat
+            else:
+                raise ValueError()
+
+        for idx, ice_idx in enumerate(ice_idx_list):
+            # NOTE: The in-context examples won't be used by now.
+
+            item = {
+                k: v
+                for k, v in retriever.test_ds[idx].items()
+                if k in input_columns or k == output_column
+            }
+            if all(isinstance(value, str) for value in item.values()):
+                # Every column is a single string
+                chat = chat_from_entry(item)
+            elif all(is_list_of(value, str) for value in item.values()):
+                # Every column is a list of string for multi-round chat
+                entries = [dict(zip(item, v)) for v in zip(*item.values())]
+                chat = sum((chat_from_entry(entry) for entry in entries), [])
+            elif len(input_columns) == 1 and is_list_of(
+                    item[input_columns[0]], dict):
+                # Single input column and it's already a chat.
+                chat = item[input_columns[0]]
+            else:
+                raise ValueError('Cannot construct chat from the dataset.')
+
+            prompt_list.append(chat)
+        return prompt_list
+
+    def infer_last(self, chat: List[dict], index: int, output_handler):
+        assistant_indices = [
+            i for i, item in enumerate(chat) if item['role'] == 'assistant'
+        ]
+
+        history = chat[:assistant_indices[-1]]
+        output = self.model.generate_from_template([history],
+                                                   max_out_len=512)[0]
+        output_handler.save_results(
+            origin_prompt=history,
+            prediction=output,
+            idx=index,
+            gold=chat[assistant_indices[-1]]['content'],
+        )
+
+    def infer_every(self, chat: List[dict], index: int, output_handler):
+        assistant_indices = [
+            i for i, item in enumerate(chat) if item['role'] == 'assistant'
+        ]
+
+        for i in assistant_indices:
+            history = chat[:i]
+            output = self.model.generate_from_template([history],
+                                                       max_out_len=512)[0]
+            output_handler.save_multiround_results(
+                origin_prompt=history[-1]['content'],
+                prediction=output,
+                idx=index,
+                gold=chat[i]['content'],
+            )
+            chat[i]['content'] = output
+            index += 1
+
+    def infer_every_with_gt(self, chat: List[dict], index: int,
+                            output_handler):
+        assistant_indices = [
+            i for i, item in enumerate(chat) if item['role'] == 'assistant'
+        ]
+
+        for i in assistant_indices:
+            history = chat[:i]
+            output = self.model.generate_from_template([history],
+                                                       max_out_len=512)[0]
+            output_handler.save_multiround_results(
+                origin_prompt=history[-1]['content'],
+                prediction=output,
+                idx=index,
+                gold=chat[i]['content'],
+            )
+            index += 1


### PR DESCRIPTION
## Motivation

Add an inferencer that accepts OpenAI chat-style messages to allow flexible message construction and multi-round chat evaluation.

## Use cases

It accepts three style dataset samples:
1. All input columns and the output column is a string. It will generate a group of OpenAI chat-style messages from the prompt template.
2. All input columns and the output column is a list of string. It will generate multiple groups of messages and concatenate them to a group of messages.
3. A single input column with a group of OpenAI chat-style messages (include both user and assistant), will be directly used.

And it has three inference modes (`infer_mode`):
- `last`: Only inference the last assistant message and all the previous messages will be recognized as history.
- `every`: Inference every assistant message, and the generated result will replace the original assistant message as the history of the next round generation. (In this mode, all ground truth assistant messages are invisible.)
- `every_with_gt`: Inference every assistant message, and the original assistant message will be used in the history of the next round generation.

![whiteboard_exported_image](https://github.com/open-compass/opencompass/assets/26739999/b521f9b8-ce71-4a26-b8b7-83b1a0896f38)


## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
