### PR TITLE
[Feature] Support the use of humaneval_plus.

### DIFF
--- a/configs/datasets/humaneval_plus/humaneval_plus_gen.py
+++ b/configs/datasets/humaneval_plus/humaneval_plus_gen.py
@@ -1,0 +1,4 @@
+from mmengine.config import read_base
+
+with read_base():
+    from .humaneval_plus_gen_8e312c import humaneval_datasets  # noqa: F401, F403

--- a/configs/datasets/humaneval_plus/humaneval_plus_gen_8e312c.py
+++ b/configs/datasets/humaneval_plus/humaneval_plus_gen_8e312c.py
@@ -1,0 +1,36 @@
+from opencompass.openicl.icl_prompt_template import PromptTemplate
+from opencompass.openicl.icl_retriever import ZeroRetriever
+from opencompass.openicl.icl_inferencer import GenInferencer
+from opencompass.datasets import HumanevalDataset, HumanEvaluator, humaneval_postprocess_v2
+
+humaneval_reader_cfg = dict(
+    input_columns=['prompt'], output_column='task_id', train_split='test')
+
+# TODO: allow empty output-column
+humaneval_infer_cfg = dict(
+    prompt_template=dict(
+        type=PromptTemplate,
+        template=dict(round=[
+            dict(
+                role='HUMAN',
+                prompt='Complete the following python code:\n{prompt}'),
+        ])),
+    retriever=dict(type=ZeroRetriever),
+    inferencer=dict(type=GenInferencer, max_out_len=512))
+
+humaneval_eval_cfg = dict(
+    evaluator=dict(type=HumanEvaluator,k=1, metric='EvalPlus'),
+    pred_role='BOT',
+    k=[1, 10, 100],  # the parameter only for humaneval
+    pred_postprocessor=dict(type=humaneval_postprocess_v2),
+)
+
+humaneval_datasets = [
+    dict(
+        abbr='humaneval_plus',
+        type=HumanevalDataset,
+        path='./data/humaneval/human-eval-v2-20210705.jsonl',
+        reader_cfg=humaneval_reader_cfg,
+        infer_cfg=humaneval_infer_cfg,
+        eval_cfg=humaneval_eval_cfg)
+]

--- a/configs/datasets/humaneval_plus/humaneval_plus_gen_8e312c.py
+++ b/configs/datasets/humaneval_plus/humaneval_plus_gen_8e312c.py
@@ -3,11 +3,11 @@ from opencompass.openicl.icl_retriever import ZeroRetriever
 from opencompass.openicl.icl_inferencer import GenInferencer
 from opencompass.datasets import HumanevalDataset, HumanEvaluator, humaneval_postprocess_v2
 
-humaneval_reader_cfg = dict(
+humaneval_plus_reader_cfg = dict(
     input_columns=['prompt'], output_column='task_id', train_split='test')
 
 # TODO: allow empty output-column
-humaneval_infer_cfg = dict(
+humaneval_plus_infer_cfg = dict(
     prompt_template=dict(
         type=PromptTemplate,
         template=dict(round=[
@@ -18,19 +18,19 @@ humaneval_infer_cfg = dict(
     retriever=dict(type=ZeroRetriever),
     inferencer=dict(type=GenInferencer, max_out_len=512))
 
-humaneval_eval_cfg = dict(
+humaneval_plus_eval_cfg = dict(
     evaluator=dict(type=HumanEvaluator,k=1, metric='EvalPlus'),
     pred_role='BOT',
     k=[1, 10, 100],  # the parameter only for humaneval
     pred_postprocessor=dict(type=humaneval_postprocess_v2),
 )
 
-humaneval_datasets = [
+humaneval_plus_datasets = [
     dict(
         abbr='humaneval_plus',
         type=HumanevalDataset,
         path='./data/humaneval/human-eval-v2-20210705.jsonl',
-        reader_cfg=humaneval_reader_cfg,
-        infer_cfg=humaneval_infer_cfg,
-        eval_cfg=humaneval_eval_cfg)
+        reader_cfg=humaneval_plus_reader_cfg,
+        infer_cfg=humaneval_plus_infer_cfg,
+        eval_cfg=humaneval_plus_eval_cfg)
 ]

--- a/opencompass/datasets/humaneval.py
+++ b/opencompass/datasets/humaneval.py
@@ -73,7 +73,7 @@ class HumanEvaluator(BaseEvaluator):
                     'git clone --recurse-submodules git@github.com:open-compass/human-eval.git\n'  # noqa
                     'cd human-eval\n'
                     'pip install -e .\n'
-                    'pip install evalplus\n')
+                    'pip install -e evalplus\n')
         self.k = k
         super().__init__()
 
@@ -121,7 +121,7 @@ class HumanEvaluator(BaseEvaluator):
                              i_just_wanna_run=None,
                              test_details=0.2,
                              min_time_limit=0.2,
-                             git_time_limit_factor=4.0,
+                             gt_time_limit_factor=4.0,
                              mini=None)
                 score = self.eval(flags)
                 return {f'humaneval_plus_{k}': score[k] * 100 for k in score}

--- a/opencompass/datasets/humaneval.py
+++ b/opencompass/datasets/humaneval.py
@@ -57,9 +57,10 @@ class HumanEvaluator(BaseEvaluator):
                 self.HUMAN_EVAL = HUMAN_EVAL
                 self.eval = evaluate_functional_correctness
             except ImportError:
-                raise ImportError('Please install human_eval following'
-                                  'https://github.com/openai/human-eval/tree/'
-                                  'master#installation first.')
+                raise ImportError(
+                    'Please install human_eval use following steps:\n'
+                    'git clone git@github.com:open-compass/human-eval.git\n'
+                    'cd human-eval && pip install -e .')
         else:
             try:
                 from evalplus.data import write_jsonl
@@ -67,7 +68,12 @@ class HumanEvaluator(BaseEvaluator):
                 self.write_jsonl = write_jsonl
                 self.eval = evaluate
             except ImportError:
-                raise ImportError('Please install eval_plus first')
+                raise ImportError(
+                    'Please install evalplus use following steps:\n'
+                    'git clone --recurse-submodules git@github.com:open-compass/human-eval.git\n'  # noqa
+                    'cd human-eval\n'
+                    'pip install -e .\n'
+                    'pip install evalplus\n')
         self.k = k
         super().__init__()
 


### PR DESCRIPTION
**How to use**
```
git clone --recurse-submodules git@github.com:open-compass/human-eval.git
cd human-eval
pip install -e .
pip install -e evalplus
```

**Results**
mistral-7b-instruct-v0.1-hf pass@1: 28.04878048780488

