### PR TITLE
[Fix]Fixed the problem of never entering task.run() mode in local scheduling mode.

### DIFF
--- a/opencompass/runners/local.py
+++ b/opencompass/runners/local.py
@@ -99,7 +99,7 @@ class LocalRunner(BaseRunner):
                     tmpl = get_command_template(all_gpu_ids[:num_gpus])
                     cmd = task.get_command(cfg_path=param_file, template=tmpl)
                     # run in subprocess if starts with torchrun etc.
-                    if 'python ' in cmd:
+                    if 'python ' in cmd or 'python3 ' in cmd:
                         task.run()
                     else:
                         subprocess.run(cmd, shell=True, text=True)

--- a/opencompass/runners/local.py
+++ b/opencompass/runners/local.py
@@ -99,7 +99,7 @@ class LocalRunner(BaseRunner):
                     tmpl = get_command_template(all_gpu_ids[:num_gpus])
                     cmd = task.get_command(cfg_path=param_file, template=tmpl)
                     # run in subprocess if starts with torchrun etc.
-                    if 'python ' in cmd or 'python3 ' in cmd:
+                    if 'python3 ' in cmd or 'python ' in cmd:
                         task.run()
                     else:
                         subprocess.run(cmd, shell=True, text=True)

--- a/opencompass/runners/local.py
+++ b/opencompass/runners/local.py
@@ -99,7 +99,7 @@ class LocalRunner(BaseRunner):
                     tmpl = get_command_template(all_gpu_ids[:num_gpus])
                     cmd = task.get_command(cfg_path=param_file, template=tmpl)
                     # run in subprocess if starts with torchrun etc.
-                    if cmd.startswith('python'):
+                    if 'python ' in cmd:
                         task.run()
                     else:
                         subprocess.run(cmd, shell=True, text=True)


### PR DESCRIPTION
get_command_template方法中为命令行前缀添加了CUDA_VISIBLE_DEVICES=或set CUDA_VISIBLE_DEVICES=。导致task.run()分支失效。 
---------
CUDA_VISIBLE_DEVICES= or set CUDA_VISIBLE_DEVICES= is added to the command line prefix in the get_command_template method. Causes the task.run() branch to fail.
