### PR TITLE
Fix FinanceIQ_datasets import error

### DIFF
--- a/configs/datasets/FinanceIQ/FinanceIQ_gen.py
+++ b/configs/datasets/FinanceIQ/FinanceIQ_gen.py
@@ -1,4 +1,4 @@
 from mmengine.config import read_base
 
 with read_base():
-    from .FinanceIQ_gen_e0e6b5 import FinanceIQ_datasets  # noqa: F401, F403
+    from .FinanceIQ_gen_e0e6b5 import financeIQ_datasets  # noqa: F401, F403

--- a/configs/datasets/FinanceIQ/FinanceIQ_ppl.py
+++ b/configs/datasets/FinanceIQ/FinanceIQ_ppl.py
@@ -1,4 +1,4 @@
 from mmengine.config import read_base
 
 with read_base():
-    from .FinanceIQ_ppl_42b9bd import FinanceIQ_datasets  # noqa: F401, F403
+    from .FinanceIQ_ppl_42b9bd import financeIQ_datasets  # noqa: F401, F403


### PR DESCRIPTION

## Motivation

This import should be `from .FinanceIQ_gen_e0e6b5 import financeIQ_datasets` instead of `FinanceIQ_datasets`.


https://github.com/open-compass/opencompass/blob/120bf8b3990e5e3c085683398edd5997b7d31005/configs/datasets/FinanceIQ/FinanceIQ_gen_e0e6b5.py#L36
