### PR TITLE
Fix running issues in turbomind_tis

### DIFF
--- a/configs/eval_internlm_chat_turbomind_tis.py
+++ b/configs/eval_internlm_chat_turbomind_tis.py
@@ -6,7 +6,7 @@ with read_base():
     from .datasets.mmlu.mmlu_gen_a484b3 import mmlu_datasets
     from .datasets.ceval.ceval_gen_5f30c7 import ceval_datasets
     from .datasets.SuperGLUE_WiC.SuperGLUE_WiC_gen_d06864 import WiC_datasets
-    from .datasets.SuperGLUE_WSC.SuperGLUE_WSC_gen_6dc406 import WSC_datasets
+    from .datasets.SuperGLUE_WSC.SuperGLUE_WSC_gen_7902a7 import WSC_datasets
     from .datasets.triviaqa.triviaqa_gen_2121ce import triviaqa_datasets
     from .datasets.gsm8k.gsm8k_gen_1d7fe4 import gsm8k_datasets
     from .datasets.humaneval.humaneval_gen_8e312c import humaneval_datasets

--- a/opencompass/models/turbomind_tis.py
+++ b/opencompass/models/turbomind_tis.py
@@ -47,6 +47,8 @@ class TurboMindTisModel(BaseModel):
         super().__init__(path=path,
                          max_seq_len=max_seq_len,
                          meta_template=meta_template)
+        from lmdeploy.serve.turbomind.utils import Preprocessor
+        self.preprocess = Preprocessor(tis_addr)
         self.logger = get_logger()
         self.template_parser = LMTemplateParser(meta_template)
         self.eos_token_id = None
@@ -82,6 +84,10 @@ class TurboMindTisModel(BaseModel):
                              [max_out_len] * len(inputs),
                              [temperature] * len(inputs)))
         return results
+
+    def get_token_len(self, prompt: str) -> int:
+        input_ids, _ = self.preprocess(prompt)
+        return input_ids.shape[-1]
 
     def wait(self):
         """Wait till the next query can be sent.


### PR DESCRIPTION
## Motivation

There are two issues for `turbomind_tis`:
1. The dataset `SuperGLUE_WSC_gen_6dc406` seems deprecated
2. The `get_token_len` method is missing in `TurboMindTisModel`, which will cause issue:
```
ine 203, in get_generation_prompt_list_from_retriever_indices
    while len(ice_idx) > 0 and prompt_token_num > max_seq_len:
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```
Because the method in `BaseModel` is empty, the `prompt_token_num` is None.

@lvhan028 pls help check

## Modification
1. Change the dataset to `SuperGLUE_WSC_gen_7902a7`
2. Add the `get_token_len` method