### PR TITLE
[fix]Fixed the issue caused by the repeated loading of VLLM model dur…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,12 +13,12 @@ exclude: |
     )
 repos:
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+    rev: 5.0.4
     hooks:
       - id: flake8
         exclude: configs/
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 5.11.5
     hooks:
       - id: isort
         exclude: configs/
@@ -28,7 +28,7 @@ repos:
       - id: yapf
         exclude: configs/
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.2.1
     hooks:
       - id: codespell
         exclude: |
@@ -37,7 +37,7 @@ repos:
                 configs/
             )
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
         exclude: |
@@ -65,7 +65,7 @@ repos:
       - id: mixed-line-ending
         args: ["--fix=lf"]
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.17
+    rev: 0.7.9
     hooks:
       - id: mdformat
         args: ["--number", "--table-width", "200"]
@@ -75,7 +75,7 @@ repos:
           - linkify-it-py
         exclude: configs/
   - repo: https://github.com/myint/docformatter
-    rev: v1.7.5
+    rev: v1.3.1
     hooks:
       - id: docformatter
         args: ["--in-place", "--wrap-descriptions", "79"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,12 +13,12 @@ exclude: |
     )
 repos:
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 7.0.0
     hooks:
       - id: flake8
         exclude: configs/
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.5
+    rev: 5.13.2
     hooks:
       - id: isort
         exclude: configs/
@@ -28,7 +28,7 @@ repos:
       - id: yapf
         exclude: configs/
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.1
+    rev: v2.2.6
     hooks:
       - id: codespell
         exclude: |
@@ -37,7 +37,7 @@ repos:
                 configs/
             )
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
         exclude: |
@@ -65,7 +65,7 @@ repos:
       - id: mixed-line-ending
         args: ["--fix=lf"]
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.9
+    rev: 0.7.17
     hooks:
       - id: mdformat
         args: ["--number", "--table-width", "200"]
@@ -75,7 +75,7 @@ repos:
           - linkify-it-py
         exclude: configs/
   - repo: https://github.com/myint/docformatter
-    rev: v1.3.1
+    rev: v1.7.5
     hooks:
       - id: docformatter
         args: ["--in-place", "--wrap-descriptions", "79"]

--- a/opencompass/models/vllm.py
+++ b/opencompass/models/vllm.py
@@ -49,6 +49,12 @@ class VLLM(BaseModel):
         model_kwargs = DEFAULT_MODEL_KWARGS.copy()
         if add_model_kwargs is not None:
             model_kwargs.update(add_model_kwargs)
+        import ray
+
+        if ray.is_initialized():
+            self.logger.info('shutdown ray instance to avoid '
+                             '"Calling ray.init() again" error.')
+            ray.shutdown()
         self.model = LLM(path, **model_kwargs)
 
     def generate(self, inputs: List[str], max_out_len: int,

--- a/opencompass/runners/local.py
+++ b/opencompass/runners/local.py
@@ -88,7 +88,7 @@ class LocalRunner(BaseRunner):
                 assert len(all_gpu_ids) >= num_gpus
                 # get cmd
                 mmengine.mkdir_or_exist('tmp/')
-                param_file = f"tmp/{os.getpid()}_params.py"
+                param_file = f'tmp/{os.getpid()}_params.py'
                 try:
                     task.cfg.dump(param_file)
                     # if use torchrun, restrict it behaves the same as non
@@ -96,8 +96,8 @@ class LocalRunner(BaseRunner):
                     # available resources which might cause inconsistent
                     # behavior.
                     if len(all_gpu_ids) > num_gpus and num_gpus > 0:
-                        get_logger().warning(f"Only use {num_gpus} GPUs for "
-                                             f"total {len(all_gpu_ids)} "
+                        get_logger().warning(f'Only use {num_gpus} GPUs for '
+                                             f'total {len(all_gpu_ids)} '
                                              'available GPUs in debug mode.')
                     tmpl = get_command_template(all_gpu_ids[:num_gpus])
                     cmd = task.get_command(cfg_path=param_file, template=tmpl)
@@ -146,10 +146,10 @@ class LocalRunner(BaseRunner):
                     time.sleep(1)
 
                 if num_gpus > 0:
-                    tqdm.write(f"launch {task.name} on GPU " +
+                    tqdm.write(f'launch {task.name} on GPU ' +
                                ','.join(map(str, gpu_ids)))
                 else:
-                    tqdm.write(f"launch {task.name} on CPU ")
+                    tqdm.write(f'launch {task.name} on CPU ')
 
                 res = self._launch(task, gpu_ids, index)
                 pbar.update()
@@ -179,7 +179,7 @@ class LocalRunner(BaseRunner):
 
         # Dump task config to file
         mmengine.mkdir_or_exist('tmp/')
-        param_file = f"tmp/{os.getpid()}_{index}_params.py"
+        param_file = f'tmp/{os.getpid()}_{index}_params.py'
         try:
             task.cfg.dump(param_file)
             tmpl = get_command_template(gpu_ids)
@@ -189,7 +189,7 @@ class LocalRunner(BaseRunner):
             cmd = get_cmd()
 
             logger = get_logger()
-            logger.debug(f"Running command: {cmd}")
+            logger.debug(f'Running command: {cmd}')
 
             # Run command
             out_path = task.get_log_path(file_extension='out')
@@ -203,7 +203,7 @@ class LocalRunner(BaseRunner):
                                     stderr=stdout)
 
             if result.returncode != 0:
-                logger.error(f"task {task_name} fail, see\n{out_path}")
+                logger.error(f'task {task_name} fail, see\n{out_path}')
         finally:
             # Clean up
             os.remove(param_file)

--- a/opencompass/tasks/openicl_infer.py
+++ b/opencompass/tasks/openicl_infer.py
@@ -50,17 +50,17 @@ class OpenICLInferTask(BaseTask):
             for key in backend_keys)
         if self.num_gpus > 0 and not use_backend:
             port = random.randint(12000, 32000)
-            command = (f"torchrun --master_port={port} "
-                       f"--nproc_per_node {self.num_procs} "
-                       f"{script_path} {cfg_path}")
+            command = (f'torchrun --master_port={port} '
+                       f'--nproc_per_node {self.num_procs} '
+                       f'{script_path} {cfg_path}')
         else:
             python = 'python3' if which('python3') else 'python'
-            command = f"{python} {script_path} {cfg_path}"
+            command = f'{python} {script_path} {cfg_path}'
 
         return template.format(task_cmd=command)
 
     def run(self, cur_model=None):
-        self.logger.info(f"Task {task_abbr_from_cfg(self.cfg)}")
+        self.logger.info(f'Task {task_abbr_from_cfg(self.cfg)}')
         for model_cfg, dataset_cfgs in zip(self.model_cfgs, self.dataset_cfgs):
             self.max_out_len = model_cfg.get('max_out_len', None)
             self.batch_size = model_cfg.get('batch_size', None)
@@ -91,7 +91,7 @@ class OpenICLInferTask(BaseTask):
 
     def _inference(self):
         self.logger.info(
-            f"Start inferencing {task_abbr_from_cfg(self.sub_cfg)}")
+            f'Start inferencing {task_abbr_from_cfg(self.sub_cfg)}')
 
         assert hasattr(self.infer_cfg, 'ice_template') or hasattr(
             self.infer_cfg, 'prompt_template'
@@ -168,4 +168,4 @@ if __name__ == '__main__':
     inferencer = OpenICLInferTask(cfg)
     inferencer.run()
     end_time = time.time()
-    get_logger().info(f"time elapsed: {end_time - start_time:.2f}s")
+    get_logger().info(f'time elapsed: {end_time - start_time:.2f}s')

--- a/opencompass/tasks/openicl_infer.py
+++ b/opencompass/tasks/openicl_infer.py
@@ -81,10 +81,8 @@ class OpenICLInferTask(BaseTask):
                     'datasets': [[self.dataset_cfg]],
                 }
                 out_path = get_infer_output_path(
-                    self.model_cfg,
-                    self.dataset_cfg,
-                    osp.join(self.work_dir, 'predictions'),
-                )
+                    self.model_cfg, self.dataset_cfg,
+                    osp.join(self.work_dir, 'predictions'))
                 if osp.exists(out_path):
                     continue
                 self._inference()
@@ -93,9 +91,8 @@ class OpenICLInferTask(BaseTask):
         self.logger.info(
             f'Start inferencing {task_abbr_from_cfg(self.sub_cfg)}')
 
-        assert hasattr(self.infer_cfg, 'ice_template') or hasattr(
-            self.infer_cfg, 'prompt_template'
-        ), 'Both ice_template and prompt_template cannot be None simultaneously.'  # noqa: E501
+        assert hasattr(self.infer_cfg, 'ice_template') or hasattr(self.infer_cfg, 'prompt_template'), \
+            'Both ice_template and prompt_template cannot be None simultaneously.'  # noqa: E501
         if hasattr(self.infer_cfg, 'ice_template'):
             ice_template = ICL_PROMPT_TEMPLATES.build(
                 self.infer_cfg['ice_template'])
@@ -125,29 +122,23 @@ class OpenICLInferTask(BaseTask):
         out_dir, out_file = osp.split(out_path)
         mkdir_or_exist(out_dir)
 
-        if hasattr(self.infer_cfg, 'prompt_template') and hasattr(
-                self.infer_cfg, 'ice_template'):
-            inferencer.inference(
-                retriever,
-                ice_template=ice_template,
-                prompt_template=prompt_template,
-                output_json_filepath=out_dir,
-                output_json_filename=out_file,
-            )
+        if hasattr(self.infer_cfg, 'prompt_template') and \
+                hasattr(self.infer_cfg, 'ice_template'):
+            inferencer.inference(retriever,
+                                 ice_template=ice_template,
+                                 prompt_template=prompt_template,
+                                 output_json_filepath=out_dir,
+                                 output_json_filename=out_file)
         elif hasattr(self.infer_cfg, 'prompt_template'):
-            inferencer.inference(
-                retriever,
-                prompt_template=prompt_template,
-                output_json_filepath=out_dir,
-                output_json_filename=out_file,
-            )
+            inferencer.inference(retriever,
+                                 prompt_template=prompt_template,
+                                 output_json_filepath=out_dir,
+                                 output_json_filename=out_file)
         else:
-            inferencer.inference(
-                retriever,
-                ice_template=ice_template,
-                output_json_filepath=out_dir,
-                output_json_filename=out_file,
-            )
+            inferencer.inference(retriever,
+                                 ice_template=ice_template,
+                                 output_json_filepath=out_dir,
+                                 output_json_filename=out_file)
 
     def _set_default_value(self, cfg: ConfigDict, key: str, value: Any):
         if key not in cfg:

--- a/opencompass/utils/build.py
+++ b/opencompass/utils/build.py
@@ -22,4 +22,5 @@ def build_model_from_cfg(model_cfg: ConfigDict):
     model_cfg.pop('summarizer_abbr', None)
     model_cfg.pop('pred_postprocessor', None)
     model_cfg.pop('min_out_len', None)
+    model_cfg.pop('tokenizer_only', None)
     return MODELS.build(model_cfg)


### PR DESCRIPTION
## Motivation

When I use VLLM, I encounter some promblems when the task is partitioned, such as: https://github.com/open-compass/opencompass/issues/1018, https://github.com/open-compass/opencompass/issues/1023#issuecomment-2042216226

The original opencompass will reload the model weights for each task (even if there is currently only one model). In order to speed up the evaluation, to avoid repeated loading, modifications need to be made to the launch function in opencompass/runners/local.py. The specific modification method is that if it is an infer type task, and if the current model has already been loaded, then it will not be loaded again.

And I think all these promblems is caused by reloading the VLLM model, so I fixed it.

I have test this code on several models via VLLM, and it works well.

## Modification

- `.pre-commit-config.yaml`
I use `pre-commit autoupdate` to update
- `opencompass/models/vllm.py`
check if ray is initialized before to avoid reinit error
- `opencompass/runners/local.py`
If it is an infer type task, do not reload if the current model has already been loaded
- `opencompass/tasks/openicl_infer.py`
If it is an infer type task, do not reload if the current model has already been loaded
- `opencompass/utils/build.py`
Fix the error "TypeError: VLLM.__init__() got an unexpected keyword argument 'tokenizer_only'"

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
