### PR TITLE
Fix VLLM argument error

### DIFF
--- a/configs/models/mistral/vllm_mistral_7b_instruct_v0_1.py
+++ b/configs/models/mistral/vllm_mistral_7b_instruct_v0_1.py
@@ -19,7 +19,7 @@ models = [
         max_seq_len=2048,
         batch_size=32,
         generation_kwargs=dict(temperature=0),
-        end_str='</s>',
+        stop_words=['</s>'],
         run_cfg=dict(num_gpus=1, num_procs=1),
     )
 ]

--- a/configs/models/mistral/vllm_mistral_7b_instruct_v0_2.py
+++ b/configs/models/mistral/vllm_mistral_7b_instruct_v0_2.py
@@ -19,7 +19,7 @@ models = [
         max_seq_len=2048,
         batch_size=32,
         generation_kwargs=dict(temperature=0),
-        end_str='</s>',
+        stop_words=['</s>'],
         run_cfg=dict(num_gpus=1, num_procs=1),
     )
 ]

--- a/configs/models/mistral/vllm_mixtral_8x7b_instruct_v0_1.py
+++ b/configs/models/mistral/vllm_mixtral_8x7b_instruct_v0_1.py
@@ -20,7 +20,7 @@ models = [
         max_seq_len=2048,
         batch_size=32,
         generation_kwargs=dict(temperature=0),
-        end_str='</s>',
+        stop_words=['</s>'],
         run_cfg=dict(num_gpus=2, num_procs=1),
     )
 ]

--- a/configs/models/others/vllm_orionstar_14b_longchat.py
+++ b/configs/models/others/vllm_orionstar_14b_longchat.py
@@ -21,6 +21,6 @@ models = [
         max_seq_len=4096,
         batch_size=32,
         run_cfg=dict(num_gpus=4, num_procs=1),
-        end_str='<|endoftext|>',
+        stop_words=['<|endoftext|>'],
     )
 ]

--- a/configs/models/qwen/vllm_qwen1_5_14b_chat.py
+++ b/configs/models/qwen/vllm_qwen1_5_14b_chat.py
@@ -19,7 +19,7 @@ models = [
         max_seq_len=2048,
         batch_size=32,
         generation_kwargs=dict(temperature=0),
-        end_str='<|im_end|>',
+        stop_words=['<|im_end|>'],
         run_cfg=dict(num_gpus=2, num_procs=1),
     )
 ]

--- a/configs/models/qwen/vllm_qwen1_5_72b_chat.py
+++ b/configs/models/qwen/vllm_qwen1_5_72b_chat.py
@@ -19,7 +19,7 @@ models = [
         max_seq_len=2048,
         batch_size=32,
         generation_kwargs=dict(temperature=0),
-        end_str='<|im_end|>',
+        stop_words=['<|im_end|>'],
         run_cfg=dict(num_gpus=4, num_procs=1),
     )
 ]

--- a/configs/models/qwen/vllm_qwen_14b_chat.py
+++ b/configs/models/qwen/vllm_qwen_14b_chat.py
@@ -19,7 +19,7 @@ models = [
         max_seq_len=2048,
         batch_size=32,
         generation_kwargs=dict(temperature=0),
-        end_str='<|im_end|>',
+        stop_words=['<|im_end|>'],
         run_cfg=dict(num_gpus=4, num_procs=1),
     )
 ]

--- a/configs/models/qwen/vllm_qwen_72b_chat.py
+++ b/configs/models/qwen/vllm_qwen_72b_chat.py
@@ -19,7 +19,7 @@ models = [
         max_seq_len=2048,
         batch_size=32,
         generation_kwargs=dict(temperature=0),
-        end_str='<|im_end|>',
+        stop_words=['<|im_end|>'],
         run_cfg=dict(num_gpus=4, num_procs=1),
     )
 ]

--- a/configs/models/vicuna/vllm_vicuna_13b_v15_16k.py
+++ b/configs/models/vicuna/vllm_vicuna_13b_v15_16k.py
@@ -17,7 +17,7 @@ models = [
         max_seq_len=2048,
         batch_size=32,
         generation_kwargs=dict(temperature=0),
-        end_str='</s>',
+        stop_words=['</s>'],
         run_cfg=dict(num_gpus=2, num_procs=1),
     )
 ]

--- a/configs/models/vicuna/vllm_vicuna_7b_v15_16k.py
+++ b/configs/models/vicuna/vllm_vicuna_7b_v15_16k.py
@@ -17,7 +17,7 @@ models = [
         max_seq_len=2048,
         batch_size=32,
         generation_kwargs=dict(temperature=0),
-        end_str='</s>',
+        stop_words=['</s>'],
         run_cfg=dict(num_gpus=1, num_procs=1),
     )
 ]

--- a/configs/models/wizardlm/vllm_wizardlm_13b_v1_2.py
+++ b/configs/models/wizardlm/vllm_wizardlm_13b_v1_2.py
@@ -18,7 +18,7 @@ models = [
         max_seq_len=2048,
         batch_size=1,
         generation_kwargs=dict(temperature=0),
-        end_str='</s>',
+        stop_words=['</s>'],
         run_cfg=dict(num_gpus=1, num_procs=1),
     )
 ]

--- a/configs/models/wizardlm/vllm_wizardlm_70b_v1_0.py
+++ b/configs/models/wizardlm/vllm_wizardlm_70b_v1_0.py
@@ -19,7 +19,7 @@ models = [
         max_seq_len=2048,
         batch_size=32,
         generation_kwargs=dict(temperature=0),
-        end_str='</s>',
+        stop_words=['</s>'],
         run_cfg=dict(num_gpus=4, num_procs=1),
     )
 ]

--- a/configs/models/wizardlm/vllm_wizardlm_7b_v1_0.py
+++ b/configs/models/wizardlm/vllm_wizardlm_7b_v1_0.py
@@ -18,7 +18,7 @@ models = [
         max_seq_len=2048,
         batch_size=32,
         generation_kwargs=dict(temperature=0),
-        end_str='</s>',
+        stop_words=['</s>'],
         run_cfg=dict(num_gpus=1, num_procs=1),
     )
 ]

--- a/configs/models/zephyr/vllm_zephyr_7b_beta.py
+++ b/configs/models/zephyr/vllm_zephyr_7b_beta.py
@@ -17,7 +17,7 @@ models = [
         max_seq_len=2048,
         batch_size=32,
         generation_kwargs=dict(temperature=0),
-        end_str='</s>',
+        stop_words=['</s>'],
         run_cfg=dict(num_gpus=1, num_procs=1),
     )
 ]


### PR DESCRIPTION


## Motivation

`TypeError: VLLM.__init__() got an unexpected keyword argument 'end_str'`

```sh
  File "/workspace/xusong/opencompass/opencompass/tasks/openicl_infer.py", line 162, in <module>
    inferencer.run()
  File "/workspace/xusong/opencompass/opencompass/tasks/openicl_infer.py", line 73, in run
    self.model = build_model_from_cfg(model_cfg)
  File "/workspace/xusong/opencompass/opencompass/utils/build.py", line 25, in build_model_from_cfg
    return MODELS.build(model_cfg)
  File "/usr/local/lib/python3.10/dist-packages/mmengine/registry/registry.py", line 570, in build
    return self.build_func(cfg, *args, **kwargs, registry=self)
  File "/usr/local/lib/python3.10/dist-packages/mmengine/registry/build_functions.py", line 121, in build_from_cfg
    obj = obj_cls(**args)  # type: ignore
TypeError: VLLM.__init__() got an unexpected keyword argument 'end_str'
```




## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
