### PR TITLE
Add `en` and `zh` groups to longbench summarizer; Fix longbench overall score

### DIFF
--- a/configs/summarizers/example.py
+++ b/configs/summarizers/example.py
@@ -12,6 +12,7 @@ with read_base():
     from .groups.xiezhi import xiezhi_summary_groups
     from .groups.scibench import scibench_summary_groups
     from .groups.mgsm import mgsm_summary_groups
+    from .groups.longbench import longbench_summary_groups
 
 summarizer = dict(
     summary_groups=sum([v for k, v in locals().items() if k.endswith('_summary_groups')], []),

--- a/configs/summarizers/groups/longbench.py
+++ b/configs/summarizers/groups/longbench.py
@@ -5,6 +5,12 @@ longbench_summary_groups = [
     {'name': 'longbench_few-shot-learning', 'subsets': ['LongBench_trec', 'LongBench_triviaqa', 'LongBench_samsum', 'LongBench_lsht']},
     {'name': 'longbench_synthetic-tasks', 'subsets': ['LongBench_passage_count', 'LongBench_passage_retrieval_en', 'LongBench_passage_retrieval_zh']},
     {'name': 'longbench_code-completion', 'subsets': ['LongBench_lcc', 'LongBench_repobench-p']},
-    {'name': 'longbench_code-completion', 'subsets': ['LongBench_lcc', 'LongBench_repobench-p']},
+    {'name': 'longbench_zh', 'subsets': ['LongBench_multifieldqa_zh', 'LongBench_dureader', 'LongBench_vcsum', 'LongBench_lsht', 'LongBench_passage_retrieval_zh']},
+    {'name': 'longbench_en', 'subsets': [
+        'LongBench_narrativeqa', 'LongBench_qasper', 'LongBench_multifieldqa_en',
+        'LongBench_hotpotqa', 'LongBench_2wikimqa', 'LongBench_musique',
+        'LongBench_gov_report', 'LongBench_qmsum', 'LongBench_multi_news',
+        'LongBench_trec', 'LongBench_triviaqa', 'LongBench_samsum',
+        'LongBench_passage_count', 'LongBench_passage_retrieval_en']},
     {'name': 'longbench', 'subsets': ['longbench_single-document-qa', 'longbench_multi-document-qa', 'longbench_summarization', 'longbench_few-shot-learning', 'longbench_synthetic-tasks', 'longbench_code-completion', 'longbench_code-completion']},
 ]

--- a/configs/summarizers/groups/longbench.py
+++ b/configs/summarizers/groups/longbench.py
@@ -5,12 +5,18 @@ longbench_summary_groups = [
     {'name': 'longbench_few-shot-learning', 'subsets': ['LongBench_trec', 'LongBench_triviaqa', 'LongBench_samsum', 'LongBench_lsht']},
     {'name': 'longbench_synthetic-tasks', 'subsets': ['LongBench_passage_count', 'LongBench_passage_retrieval_en', 'LongBench_passage_retrieval_zh']},
     {'name': 'longbench_code-completion', 'subsets': ['LongBench_lcc', 'LongBench_repobench-p']},
-    {'name': 'longbench_zh', 'subsets': ['LongBench_multifieldqa_zh', 'LongBench_dureader', 'LongBench_vcsum', 'LongBench_lsht', 'LongBench_passage_retrieval_zh']},
+
+    # code tasks are included in both longbench_zh and longbench_en
+    {'name': 'longbench_zh', 'subsets': ['LongBench_multifieldqa_zh', 'LongBench_dureader', 'LongBench_vcsum',
+                                         'LongBench_lsht', 'LongBench_passage_retrieval_zh',
+                                         'LongBench_lcc', 'LongBench_repobench-p']},
     {'name': 'longbench_en', 'subsets': [
         'LongBench_narrativeqa', 'LongBench_qasper', 'LongBench_multifieldqa_en',
         'LongBench_hotpotqa', 'LongBench_2wikimqa', 'LongBench_musique',
         'LongBench_gov_report', 'LongBench_qmsum', 'LongBench_multi_news',
         'LongBench_trec', 'LongBench_triviaqa', 'LongBench_samsum',
-        'LongBench_passage_count', 'LongBench_passage_retrieval_en']},
+        'LongBench_passage_count', 'LongBench_passage_retrieval_en',
+        'LongBench_lcc', 'LongBench_repobench-p'
+    ]},
     {'name': 'longbench', 'subsets': ['longbench_single-document-qa', 'longbench_multi-document-qa', 'longbench_summarization', 'longbench_few-shot-learning', 'longbench_synthetic-tasks', 'longbench_code-completion', 'longbench_code-completion']},
 ]

--- a/configs/summarizers/groups/longbench.py
+++ b/configs/summarizers/groups/longbench.py
@@ -18,5 +18,5 @@ longbench_summary_groups = [
         'LongBench_passage_count', 'LongBench_passage_retrieval_en',
         'LongBench_lcc', 'LongBench_repobench-p'
     ]},
-    {'name': 'longbench', 'subsets': ['longbench_single-document-qa', 'longbench_multi-document-qa', 'longbench_summarization', 'longbench_few-shot-learning', 'longbench_synthetic-tasks', 'longbench_code-completion', 'longbench_code-completion']},
+    {'name': 'longbench', 'subsets': ['longbench_single-document-qa', 'longbench_multi-document-qa', 'longbench_summarization', 'longbench_few-shot-learning', 'longbench_synthetic-tasks', 'longbench_code-completion']},
 ]


### PR DESCRIPTION
## Motivation


1. `longbench_zh` and `longbench_en` are important metrics.
https://github.com/THUDM/LongBench/tree/main?tab=readme-ov-file#leaderboard

2.  `longbench_code-completion` was counted twice in `longbench` group.

## Modification

- remove duplicated `longbench_code-completion`
- add `longbench_zh` and `longbench_en`
- Fix `longbench` calculation


## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
