### PR TITLE
npu适配

### DIFF
--- a/opencompass/runners/local.py
+++ b/opencompass/runners/local.py
@@ -27,7 +27,7 @@ def get_command_template(gpu_ids: List[int]) -> str:
         tmpl = 'set CUDA_VISIBLE_DEVICES=' + ','.join(str(i) for i in gpu_ids)
         tmpl += ' & {task_cmd}'
     else:
-        tmpl = 'CUDA_VISIBLE_DEVICES=' + ','.join(str(i) for i in gpu_ids)
+        tmpl = 'ASCEND_RT_VISIBLE_DEVICES=' + ','.join(str(i) for i in gpu_ids)
         tmpl += ' {task_cmd}'
     return tmpl
 
@@ -73,6 +73,7 @@ class LocalRunner(BaseRunner):
 
         status = []
         import torch
+        import torch_npu
 
         if 'CUDA_VISIBLE_DEVICES' in os.environ:
             all_gpu_ids = [

--- a/opencompass/runners/local.py
+++ b/opencompass/runners/local.py
@@ -86,8 +86,8 @@ class LocalRunner(BaseRunner):
             device_nums = torch.cuda.device_count()
         if visible_devices in os.environ:
             all_gpu_ids = [
-                int(i) for i in re.findall(r'(?<!-)\d+',
-                                           os.getenv(visible_devices))
+                int(i)
+                for i in re.findall(r'(?<!-)\d+', os.getenv(visible_devices))
             ]
         else:
             all_gpu_ids = list(range(device_nums))

--- a/opencompass/runners/local.py
+++ b/opencompass/runners/local.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Tuple
 import mmengine
 import numpy as np
 from mmengine.config import ConfigDict
+from mmengine.device import is_npu_available
 from tqdm import tqdm
 
 from opencompass.registry import RUNNERS, TASKS
@@ -22,12 +23,15 @@ from .base import BaseRunner
 
 def get_command_template(gpu_ids: List[int]) -> str:
     """Format command template given available gpu ids."""
-    if sys.platform == 'win32':  # Always return win32 for Windows
+    if is_npu_available():
+        tmpl = 'ASCEND_RT_VISIBLE_DEVICES=' + ','.join(str(i) for i in gpu_ids)
+        tmpl += ' & {task_cmd}'
+    elif sys.platform == 'win32':  # Always return win32 for Windows
         # use command in Windows format
         tmpl = 'set CUDA_VISIBLE_DEVICES=' + ','.join(str(i) for i in gpu_ids)
         tmpl += ' & {task_cmd}'
     else:
-        tmpl = 'ASCEND_RT_VISIBLE_DEVICES=' + ','.join(str(i) for i in gpu_ids)
+        tmpl = 'CUDA_VISIBLE_DEVICES=' + ','.join(str(i) for i in gpu_ids)
         tmpl += ' {task_cmd}'
     return tmpl
 
@@ -73,15 +77,20 @@ class LocalRunner(BaseRunner):
 
         status = []
         import torch
-        import torch_npu
 
-        if 'CUDA_VISIBLE_DEVICES' in os.environ:
+        if is_npu_available():
+            visible_devices = 'ASCEND_RT_VISIBLE_DEVICES'
+            device_nums = torch.npu.device_count()
+        else:
+            visible_devices = 'CUDA_VISIBLE_DEVICES'
+            device_nums = torch.cuda.device_count()
+        if visible_devices in os.environ:
             all_gpu_ids = [
                 int(i) for i in re.findall(r'(?<!-)\d+',
-                                           os.getenv('CUDA_VISIBLE_DEVICES'))
+                                           os.getenv(visible_devices))
             ]
         else:
-            all_gpu_ids = list(range(torch.cuda.device_count()))
+            all_gpu_ids = list(range(device_nums))
 
         if self.debug:
             for task in tasks:


### PR DESCRIPTION
### What does this PR do?
We use this PR to adapt Opencompass to the NPU for huggingface side code. This change can help us evaluate the quality and effectiveness of NLP models on NPU.

By using `mmengine.device` to import `is_npu_available`, we can determine whether it is currently running on the NPU environment. That is to say, if `is_npu_available()` returns `True`, it indicates that there is an available NPU in the running environment. And then, we can use `torch.npu.device_count()` to determine the currently available devices.

### What is Ascend and torch_npu
The following information is quoted from: https://github.com/Lightning-AI/pytorch-lightning/issues/19498#issue-2143434187

1. Ascend is a full-stack AI computing infrastructure for industry applications and services based on Huawei Ascend processors and software. For more information about Ascend, see [Ascend Community](https://www.hiascend.com/en/).
2. torch_npu is an [officially recognized pytorch integration plugin](https://pytorch.org/blog/pytorch-2-1/) to support Ascend NPU using the pytorch framework(through key PRivateUse1), please see the PrivateUse1 tutorial [here](https://pytorch.org/tutorials/advanced/privateuseone.html).
3. Ascend is currently one of the premier members of the [PyTorch Foundation](https://pytorch.org/blog/huawei-joins-pytorch/).