### PR TITLE
add ",<2.0.0" to "numpy>=1.23.4" in requirements/runtime.txt, as pand…

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -16,7 +16,7 @@ langdetect
 ltp
 mmengine-lite
 nltk==3.8
-numpy>=1.23.4
+numpy>=1.23.4,<2.0.0
 openai
 OpenCC
 opencv-python-headless


### PR DESCRIPTION
…as<2.0.0 doesn't compatible with numpy>=2.0.0

## Motivation

Can't run `python run.py -h` after following the instructions in <https://github.com/Zor-X-L/opencompass#%EF%B8%8F-installation>, because `pip install -e .` installs numpy 2.0.0 which is incompatible with pandas<2.0.0

## Modification

In requirements/runtime.txt, change "numpy>=1.23.4" to "numpy>=1.23.4,<2.0.0"

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

None of them are relavant I think.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.

This modification has no influence on downstream or other related projects I think.