### PR TITLE
Add icl_sliding_k_retriever.py and update __init__.py

### DIFF
--- a/opencompass/openicl/icl_retriever/__init__.py
+++ b/opencompass/openicl/icl_retriever/__init__.py
@@ -7,3 +7,4 @@ from .icl_random_retriever import RandomRetriever  # noqa
 from .icl_topk_retriever import TopkRetriever  # noqa
 from .icl_votek_retriever import VotekRetriever  # noqa
 from .icl_zero_retriever import ZeroRetriever  # noqa
+from .icl_sliding_k_retriever import SlidingWindowRetriever  # noqa

--- a/opencompass/openicl/icl_retriever/icl_sliding_k_retriever.py
+++ b/opencompass/openicl/icl_retriever/icl_sliding_k_retriever.py
@@ -1,6 +1,6 @@
 """Sliding Window Retriever."""
 
-from typing import List, Optional
+from typing import Optional
 
 from tqdm import trange
 
@@ -17,16 +17,21 @@ class SlidingWindowRetriever(BaseRetriever):
     retrieved based on a sliding window from the index set.
 
     Args:
-        dataset (`BaseDataset`): Any BaseDataset instances.
+        dataset (`BaseDataset`):
+            Any BaseDataset instances.
             Attributes of ``reader``, ``train`` and ``test`` will be used.
-        k (int): The number of in-context examples to retrieve for each test prompt.
-        ice_separator (`Optional[str]`): The separator between each in-context
+        k (int):
+            The number of in-context examples to retrieve for each test prompt.
+        ice_separator (`Optional[str]`):
+            The separator between each in-context
             example template when origin `PromptTemplate` is provided. Defaults
             to '\n'.
-        ice_eos_token (`Optional[str]`): The end of sentence token for
+        ice_eos_token (`Optional[str]`):
+            The end of sentence token for
             in-context example template when origin `PromptTemplate` is
             provided. Defaults to '\n'.
-        ice_num (`Optional[int]`): The number of in-context example template
+        ice_num (`Optional[int]`):
+            The number of in-context example template
             when origin `PromptTemplate` is provided. Defaults to 1.
     """
 
@@ -43,16 +48,20 @@ class SlidingWindowRetriever(BaseRetriever):
         """Retrieve the in-context example index for each test example."""
         num_idx = len(self.index_ds)
         rtr_idx_list = []
-        for current_index in trange(len(self.test_ds), disable=not self.is_main_process):
+        for current_index in trange(len(self.test_ds),
+                                    disable=not self.is_main_process):
             if current_index < self.k:
-                # For the first few examples, get the previous ones and pad with the last ones
+                """For the first few examples,
+                get the previous ones and pad with the last ones"""
                 start_index = max(0, current_index - self.k)
                 previous_shots = list(range(start_index, current_index))
                 if len(previous_shots) < self.k:
                     pad_needed = self.k - len(previous_shots)
-                    previous_shots = list(range(num_idx - pad_needed, num_idx)) + previous_shots
+                    previous_shots = list(range(num_idx - pad_needed,
+                                                num_idx)) + previous_shots
             else:
                 # For other examples, retrieve the previous k examples
-                previous_shots = list(range(current_index - self.k, current_index))
+                previous_shots = list(
+                    range(current_index - self.k, current_index))
             rtr_idx_list.append(previous_shots)
         return rtr_idx_list

--- a/opencompass/openicl/icl_retriever/icl_sliding_k_retriever.py
+++ b/opencompass/openicl/icl_retriever/icl_sliding_k_retriever.py
@@ -1,0 +1,58 @@
+"""Sliding Window Retriever."""
+
+from typing import List, Optional
+
+from tqdm import trange
+
+from opencompass.openicl.icl_retriever import BaseRetriever
+from opencompass.openicl.utils.logging import get_logger
+from opencompass.registry import ICL_RETRIEVERS
+
+logger = get_logger(__name__)
+
+
+@ICL_RETRIEVERS.register_module()
+class SlidingWindowRetriever(BaseRetriever):
+    """Sliding Window Retriever. Each in-context example of the test prompts is
+    retrieved based on a sliding window from the index set.
+
+    Args:
+        dataset (`BaseDataset`): Any BaseDataset instances.
+            Attributes of ``reader``, ``train`` and ``test`` will be used.
+        k (int): The number of in-context examples to retrieve for each test prompt.
+        ice_separator (`Optional[str]`): The separator between each in-context
+            example template when origin `PromptTemplate` is provided. Defaults
+            to '\n'.
+        ice_eos_token (`Optional[str]`): The end of sentence token for
+            in-context example template when origin `PromptTemplate` is
+            provided. Defaults to '\n'.
+        ice_num (`Optional[int]`): The number of in-context example template
+            when origin `PromptTemplate` is provided. Defaults to 1.
+    """
+
+    def __init__(self,
+                 dataset,
+                 k: int,
+                 ice_separator: Optional[str] = '\n',
+                 ice_eos_token: Optional[str] = '\n',
+                 ice_num: Optional[int] = 1) -> None:
+        super().__init__(dataset, ice_separator, ice_eos_token, ice_num)
+        self.k = k
+
+    def retrieve(self):
+        """Retrieve the in-context example index for each test example."""
+        num_idx = len(self.index_ds)
+        rtr_idx_list = []
+        for current_index in trange(len(self.test_ds), disable=not self.is_main_process):
+            if current_index < self.k:
+                # For the first few examples, get the previous ones and pad with the last ones
+                start_index = max(0, current_index - self.k)
+                previous_shots = list(range(start_index, current_index))
+                if len(previous_shots) < self.k:
+                    pad_needed = self.k - len(previous_shots)
+                    previous_shots = list(range(num_idx - pad_needed, num_idx)) + previous_shots
+            else:
+                # For other examples, retrieve the previous k examples
+                previous_shots = list(range(current_index - self.k, current_index))
+            rtr_idx_list.append(previous_shots)
+        return rtr_idx_list


### PR DESCRIPTION
## Motivation
This PR aims to introduce a new Sliding Window Retriever for in-context learning. The goal is to enhance the flexibility and effectiveness of example retrieval in the OpenCompass framework, particularly for scenarios where context relevance varies with the position of test examples.

## Modification
This PR introduces two main modifications:
1. Added a new file `icl_sliding_k_retriever.py` implementing the `SlidingWindowRetriever` class.
2. Updated `__init__.py` to include the new `SlidingWindowRetriever` in the package exports.

The `SlidingWindowRetriever` allows for dynamic selection of in-context examples based on a sliding window approach, which can be particularly useful for tasks where the relevance of context changes as we progress through the dataset.

## BC-breaking (Optional)
This modification does not introduce any changes that break backward compatibility. Existing retriever implementations remain unchanged, and this new retriever can be used alongside them without conflicts.

## Use cases (Optional)
The `SlidingWindowRetriever` can be particularly useful in scenarios such as:
1. Time-series data analysis where recent context is more relevant.
2. Document processing tasks where context relevance changes throughout the document.
3. Any task where the order of examples matters and using a fixed set of examples throughout might not be optimal.

To use the new retriever, users can specify it in their configuration files like so:

```python
retriever = dict(type='SlidingWindowRetriever',
                 dataset=dataset,
                 k=5)  # retrieves 5 previous examples
```

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
