### PR TITLE
[Feature] Switch to python runner for single GPU

### DIFF
--- a/opencompass/tasks/openicl_infer.py
+++ b/opencompass/tasks/openicl_infer.py
@@ -50,7 +50,7 @@ class OpenICLInferTask(BaseTask):
             key in str(self.model_cfgs[0].get('type', ''))
             or key in str(self.model_cfgs[0].get('llm', {}).get('type', ''))
             for key in backend_keys)
-        if self.num_gpus > 0 and not use_backend:
+        if self.num_gpus > 1 and not use_backend:
             port = random.randint(12000, 32000)
             command = (f'torchrun --master_port={port} '
                        f'--nproc_per_node {self.num_procs} '


### PR DESCRIPTION
## Motivation

There is no need to use `torchrun` for single GPU inference. 
Besides, `python` runner is more friendly for debugging.
The debugging snippet is as follows
https://github.com/open-compass/opencompass/blob/889e7e11409d83fe312ecc7d7f0ed8861a84cc92/opencompass/runners/local.py#L116-L131
