### PR TITLE
Upgrade default math `pred_postprocessor`

### DIFF
--- a/configs/datasets/math/math_gen_265cce.py
+++ b/configs/datasets/math/math_gen_265cce.py
@@ -23,7 +23,7 @@ math_infer_cfg = dict(
     inferencer=dict(type=GenInferencer, max_out_len=512))
 
 math_eval_cfg = dict(
-    evaluator=dict(type=MATHEvaluator), pred_postprocessor=dict(type=math_postprocess_v2))
+    evaluator=dict(type=MATHEvaluator, version='v2'), pred_postprocessor=dict(type=math_postprocess_v2))
 
 math_datasets = [
     dict(

--- a/configs/datasets/math/math_gen_265cce.py
+++ b/configs/datasets/math/math_gen_265cce.py
@@ -1,7 +1,7 @@
 from opencompass.openicl.icl_prompt_template import PromptTemplate
 from opencompass.openicl.icl_retriever import ZeroRetriever
 from opencompass.openicl.icl_inferencer import GenInferencer
-from opencompass.datasets import MATHDataset, MATHEvaluator, math_postprocess
+from opencompass.datasets import MATHDataset, MATHEvaluator, math_postprocess_v2
 
 math_reader_cfg = dict(input_columns=['problem'], output_column='solution')
 
@@ -23,7 +23,7 @@ math_infer_cfg = dict(
     inferencer=dict(type=GenInferencer, max_out_len=512))
 
 math_eval_cfg = dict(
-    evaluator=dict(type=MATHEvaluator), pred_postprocessor=dict(type=math_postprocess))
+    evaluator=dict(type=MATHEvaluator), pred_postprocessor=dict(type=math_postprocess_v2))
 
 math_datasets = [
     dict(


### PR DESCRIPTION
Upgrade default math pred_postprocessor from `math_postprocess` to `math_postprocess_v2`

## Motivation

As mentioned in [document](https://github.com/open-compass/opencompass/tree/main/configs/datasets/math#math), the default pred_postprocessor is `math_postprocess_v2` in both [`math_4shot_base_gen_db136b`](https://github.com/open-compass/opencompass/blob/main/configs/datasets/math/math_4shot_base_gen_db136b.py) and [`math_0shot_gen_393424`](https://github.com/open-compass/opencompass/blob/main/configs/datasets/math/math_0shot_gen_393424.py).


`math_postprocess_v2` is more robust than `math_postprocess`.
https://github.com/open-compass/opencompass/blob/1f9f728f2262a0bd0b9a942d0db4f36841444c77/opencompass/datasets/math.py#L158-L161
