### PR TITLE
[Fix] Fix InternLM2.5-7B-Chat-1M config

### DIFF
--- a/configs/models/hf_internlm/lmdeploy_internlm2_5_7b_chat_1m.py
+++ b/configs/models/hf_internlm/lmdeploy_internlm2_5_7b_chat_1m.py
@@ -5,7 +5,7 @@ models = [
         type=TurboMindModelwithChatTemplate,
         abbr='internlm2_5-7b-chat-1m-turbomind',
         path='internlm/internlm2_5-7b-chat-1m',
-        engine_config=dict(rope_scaling_factor=2.5, session_len=1048576, max_batch_size=1, tp=4), # 1M context length
+        engine_config=dict(rope_scaling_factor=2.5, session_len=1048576, max_batch_size=1, cache_max_entry_count=0.7, tp=4), # 1M context length
         gen_config=dict(top_k=1, temperature=1e-6, top_p=0.9, max_new_tokens=2048),
         max_seq_len=1048576,
         max_out_len=2048,


### PR DESCRIPTION
This PR updates the config file for the InternLM2.5-7B-Chat-1M model. The modifications ensure that the configuration is consistent with the parameters provided on the [official Hugging Face page](https://huggingface.co/internlm/internlm2_5-7b-chat-1m#:~:text=You%20can%20run%20batch%20inference%20locally%20with%20the%20following%20python%20code%3A).
<img width="633" alt="image" src="https://github.com/user-attachments/assets/567232a5-1c28-4f1c-9c9c-14c883d0dd1c">
