### PR TITLE
[Feature] Add abbr for rolebench dataset

### DIFF
--- a/configs/datasets/rolebench/instruction_generalization_eng.py
+++ b/configs/datasets/rolebench/instruction_generalization_eng.py
@@ -33,6 +33,7 @@ instruction_generalization_eng_eval_cfg = dict(
 
 instruction_generalization_eng_datasets = [
     dict(
+        abbr='RoleBench_instruct_eng',
         type=InstructionGeneralizationEnglishDataset,
         path='ZenMoore/RoleBench',
         reader_cfg=instruction_generalization_eng_reader_cfg,

--- a/configs/datasets/rolebench/instruction_generalization_zh.py
+++ b/configs/datasets/rolebench/instruction_generalization_zh.py
@@ -33,6 +33,7 @@ instruction_generalization_zh_eval_cfg = dict(
 
 instruction_generalization_zh_datasets = [
     dict(
+        abbr='RoleBench_instruct_zh',
         type=InstructionGeneralizationChineseDataset,
         path='ZenMoore/RoleBench',
         reader_cfg=instruction_generalization_zh_reader_cfg,

--- a/configs/datasets/rolebench/role_generalization_eng.py
+++ b/configs/datasets/rolebench/role_generalization_eng.py
@@ -33,6 +33,7 @@ role_generalization_eng_eval_cfg = dict(
 
 role_generalization_eng_datasets = [
     dict(
+        abbr='RoleBench_role_eng',
         type=RoleGeneralizationEnglishDataset,
         path='ZenMoore/RoleBench',
         reader_cfg=role_generalization_eng_reader_cfg,

--- a/opencompass/configs/datasets/rolebench/instruction_generalization_eng.py
+++ b/opencompass/configs/datasets/rolebench/instruction_generalization_eng.py
@@ -33,6 +33,7 @@ instruction_generalization_eng_eval_cfg = dict(
 
 instruction_generalization_eng_datasets = [
     dict(
+        abbr='RoleBench_instruct_eng',
         type=InstructionGeneralizationEnglishDataset,
         path='ZenMoore/RoleBench',
         reader_cfg=instruction_generalization_eng_reader_cfg,

--- a/opencompass/configs/datasets/rolebench/instruction_generalization_zh.py
+++ b/opencompass/configs/datasets/rolebench/instruction_generalization_zh.py
@@ -33,6 +33,7 @@ instruction_generalization_zh_eval_cfg = dict(
 
 instruction_generalization_zh_datasets = [
     dict(
+        abbr='RoleBench_instruct_zh',
         type=InstructionGeneralizationChineseDataset,
         path='ZenMoore/RoleBench',
         reader_cfg=instruction_generalization_zh_reader_cfg,

--- a/opencompass/configs/datasets/rolebench/role_generalization_eng.py
+++ b/opencompass/configs/datasets/rolebench/role_generalization_eng.py
@@ -33,6 +33,7 @@ role_generalization_eng_eval_cfg = dict(
 
 role_generalization_eng_datasets = [
     dict(
+        abbr='RoleBench_role_eng',
         type=RoleGeneralizationEnglishDataset,
         path='ZenMoore/RoleBench',
         reader_cfg=role_generalization_eng_reader_cfg,


### PR DESCRIPTION
## Motivation

`instruction_generalization_eng`, `instruction_generalization_zh`, `role_generalization_eng` get the same abbr, which cause error in evaluation.


```
python run.py --models hf_llama_7b --datasets instruction_generalization_eng instruction_generalization_zh
```
