### PR TITLE
fix: IFEval dataset introduces the correct langdetect expectation path

### DIFF
--- a/opencompass/datasets/IFEval/instructions.py
+++ b/opencompass/datasets/IFEval/instructions.py
@@ -163,7 +163,7 @@ class ResponseLanguageChecker(Instruction):
 
         try:
             return langdetect.detect(value) == self._language
-        except langdetect.LangDetectException as e:
+        except langdetect.lang_detect_exception.LangDetectException as e:
             # Count as instruction is followed.
             logging.error('Unable to detect language for text %s due to %s',
                           value, e)  # refex: disable=pytotw.037
@@ -1424,7 +1424,7 @@ class CapitalLettersEnglishChecker(Instruction):
 
         try:
             return value.isupper() and langdetect.detect(value) == 'en'
-        except langdetect.LangDetectException as e:
+        except langdetect.lang_detect_exception.LangDetectException as e:
             # Count as instruction is followed.
             logging.error('Unable to detect language for text %s due to %s',
                           value, e)  # refex: disable=pytotw.037
@@ -1456,7 +1456,7 @@ class LowercaseLettersEnglishChecker(Instruction):
 
         try:
             return value.islower() and langdetect.detect(value) == 'en'
-        except langdetect.LangDetectException as e:
+        except langdetect.lang_detect_exception.LangDetectException as e:
             # Count as instruction is followed.
             logging.error('Unable to detect language for text %s due to %s',
                           value, e)  # refex: disable=pytotw.037


### PR DESCRIPTION
## Motivation
When I tested the IFEval dataset locally, I found that this error would occur during the evaluation.

Traceback (most recent call last):
  File "C:\Users\12072\.projects\PyCharmProjects\evaluation\executor\opencompass\opencompass\tasks\openicl_eval.py", line 364, in <module>
    inferencer.run()
  File "C:\Users\12072\.projects\PyCharmProjects\evaluation\executor\opencompass\opencompass\tasks\openicl_eval.py", line 110, in run
    self._score()
  File "C:\Users\12072\.projects\PyCharmProjects\evaluation\executor\opencompass\opencompass\tasks\openicl_eval.py", line 219, in _score
    result = icl_evaluator.score(**preds)
  File "C:\Users\12072\.projects\PyCharmProjects\evaluation\executor\opencompass\opencompass\datasets\IFEval\ifeval.py", line 49, in score
    example = test_instruction_following_strict(input, pred)
  File "C:\Users\12072\.projects\PyCharmProjects\evaluation\executor\opencompass\opencompass\datasets\IFEval\evaluation_main.py", line 77, in test_instruction_following_strict
    if response.strip() and instruction.check_following(response):
  File "C:\Users\12072\.projects\PyCharmProjects\evaluation\executor\opencompass\opencompass\datasets\IFEval\instructions.py", line 166, in check_following
    except langdetect.LangDetectException as e:
AttributeError: module 'langdetect' has no attribute 'LangDetectException'. Did you mean: 'lang_detect_exception'?

This seems to be caused by introducing the wrong path

## Modification
I modified this path to be correct to avoid the problem of evaluation failure.