### PR TITLE
Add WMT19 dataset configuration and inference code

### DIFF
--- a/configs/datasets/wmt19/wmt19_gen.py
+++ b/configs/datasets/wmt19/wmt19_gen.py
@@ -1,0 +1,122 @@
+from opencompass.openicl.icl_prompt_template import PromptTemplate
+from opencompass.openicl.icl_retriever import ZeroRetriever, BM25Retriever
+from opencompass.openicl.icl_inferencer import GenInferencer
+from opencompass.openicl.icl_evaluator import BleuEvaluator
+from opencompass.datasets.wmt19 import WMT19TranslationDataset
+
+LANG_CODE_TO_NAME = {
+    'cs': 'Czech',
+    'de': 'German',
+    'en': 'English',
+    'fi': 'Finnish',
+    'fr': 'French',
+    'gu': 'Gujarati',
+    'kk': 'Kazakh',
+    'lt': 'Lithuanian',
+    'ru': 'Russian',
+    'zh': 'Chinese'
+}
+
+wmt19_reader_cfg = dict(
+    input_columns=['input'],
+    output_column='target',
+    train_split='validation',
+    test_split='validation')
+
+wmt19_infer_cfg_0shot = dict(
+    prompt_template=dict(
+        type=PromptTemplate,
+        template=dict(
+            round=[
+                dict(role='HUMAN', prompt='Translate the following {src_lang_name} text to {tgt_lang_name}:\n{{input}}\n'),
+                dict(role='BOT', prompt='Translation:\n')
+            ]
+        )
+    ),
+    retriever=dict(type=ZeroRetriever),
+    inferencer=dict(type=GenInferencer)
+)
+
+wmt19_infer_cfg_5shot = dict(
+    ice_template=dict(
+        type=PromptTemplate,
+        template='Example:\n{src_lang_name}: {{input}}\n{tgt_lang_name}: {{target}}'
+    ),
+    prompt_template=dict(
+        type=PromptTemplate,
+        template='</E>\nTranslate the following {src_lang_name} text to {tgt_lang_name}:\n{{input}}\nTranslation:\n',
+        ice_token='</E>',
+    ),
+    retriever=dict(type=BM25Retriever, ice_num=5),
+    inferencer=dict(type=GenInferencer),
+)
+
+wmt19_eval_cfg = dict(
+    evaluator=dict(
+        type=BleuEvaluator
+    ),
+    pred_role='BOT',
+)
+
+language_pairs = [
+    ('cs', 'en'), ('de', 'en'), ('fi', 'en'), ('fr', 'de'), 
+    ('gu', 'en'), ('kk', 'en'), ('lt', 'en'), ('ru', 'en'), ('zh', 'en')
+]
+
+wmt19_datasets = []
+
+for src_lang, tgt_lang in language_pairs:
+    src_lang_name = LANG_CODE_TO_NAME[src_lang]
+    tgt_lang_name = LANG_CODE_TO_NAME[tgt_lang]
+    
+    wmt19_datasets.extend([
+        dict(
+            abbr=f'wmt19_{src_lang}-{tgt_lang}_0shot',
+            type=WMT19TranslationDataset,
+            path='/path/to/wmt19',
+            src_lang=src_lang,
+            tgt_lang=tgt_lang,
+            reader_cfg=wmt19_reader_cfg,
+            infer_cfg={
+                **wmt19_infer_cfg_0shot,
+                'prompt_template': {
+                    **wmt19_infer_cfg_0shot['prompt_template'],
+                    'template': {
+                        **wmt19_infer_cfg_0shot['prompt_template']['template'],
+                        'round': [
+                            {
+                                **wmt19_infer_cfg_0shot['prompt_template']['template']['round'][0],
+                                'prompt': wmt19_infer_cfg_0shot['prompt_template']['template']['round'][0]['prompt'].format(
+                                    src_lang_name=src_lang_name, tgt_lang_name=tgt_lang_name
+                                )
+                            },
+                            wmt19_infer_cfg_0shot['prompt_template']['template']['round'][1]
+                        ]
+                    }
+                }
+            },
+            eval_cfg=wmt19_eval_cfg),
+        dict(
+            abbr=f'wmt19_{src_lang}-{tgt_lang}_5shot',
+            type=WMT19TranslationDataset,
+            path='/path/to/wmt19',
+            src_lang=src_lang,
+            tgt_lang=tgt_lang,
+            reader_cfg=wmt19_reader_cfg,
+            infer_cfg={
+                **wmt19_infer_cfg_5shot,
+                'ice_template': {
+                    **wmt19_infer_cfg_5shot['ice_template'],
+                    'template': wmt19_infer_cfg_5shot['ice_template']['template'].format(
+                        src_lang_name=src_lang_name, tgt_lang_name=tgt_lang_name
+                    )
+                },
+                'prompt_template': {
+                    **wmt19_infer_cfg_5shot['prompt_template'],
+                    'template': wmt19_infer_cfg_5shot['prompt_template']['template'].format(
+                        src_lang_name=src_lang_name, tgt_lang_name=tgt_lang_name
+                    )
+                }
+            },
+            eval_cfg=wmt19_eval_cfg),
+    ])

--- a/opencompass/datasets/__init__.py
+++ b/opencompass/datasets/__init__.py
@@ -121,6 +121,7 @@ from .wic import *  # noqa: F401, F403
 from .wikibench import *  # noqa: F401, F403
 from .winograd import *  # noqa: F401, F403
 from .winogrande import *  # noqa: F401, F403
+from .wmt19 import * # noqa: F401, F403
 from .wnli import wnliDataset  # noqa: F401, F403
 from .wsc import *  # noqa: F401, F403
 from .xcopa import *  # noqa: F401, F403

--- a/opencompass/datasets/wmt19.py
+++ b/opencompass/datasets/wmt19.py
@@ -1,0 +1,38 @@
+import os
+import pandas as pd
+from datasets import Dataset, DatasetDict
+from opencompass.registry import LOAD_DATASET
+from opencompass.datasets.base import BaseDataset
+
+@LOAD_DATASET.register_module()
+class WMT19TranslationDataset(BaseDataset):
+    @staticmethod
+    def load(path: str, src_lang: str, tgt_lang: str):
+        print(f"Attempting to load data from path: {path}")
+        print(f"Source language: {src_lang}, Target language: {tgt_lang}")
+
+        lang_pair_dir = os.path.join(path, f"{src_lang}-{tgt_lang}")
+        if not os.path.exists(lang_pair_dir):
+            lang_pair_dir = os.path.join(path, f"{tgt_lang}-{src_lang}")
+            if not os.path.exists(lang_pair_dir):
+                raise ValueError(f"Cannot find directory for language pair {src_lang}-{tgt_lang} or {tgt_lang}-{src_lang}")
+
+        print(f"Loading data from directory: {lang_pair_dir}")
+
+        val_file = os.path.join(lang_pair_dir, "validation-00000-of-00001.parquet")
+        val_df = pd.read_parquet(val_file)
+
+        def process_split(df):
+            return Dataset.from_dict({
+                'input': df['translation'].apply(lambda x: x[src_lang]).tolist(),
+                'target': df['translation'].apply(lambda x: x[tgt_lang]).tolist()
+            })
+
+        return DatasetDict({
+            'validation': process_split(val_df)
+        })
+
+    @classmethod
+    def get_dataset(cls, path, src_lang, tgt_lang):
+        return cls.load(path, src_lang, tgt_lang)
+


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

This pull request aims to introduce support for the WMT19 dataset within the opencompass framework. The WMT19 dataset is widely used for machine translation tasks, and by adding it to opencompass, we extend the framework’s coverage for benchmarking large models on translation tasks.

## Modification

In this PR, I have added:
1. A new dataset configuration file (`wmt19.py`) that defines the dataset loading and pre-processing for the WMT19 dataset.
2. An inference script (`wmt19_gen.py`) that handles the evaluation of models on the WMT19 dataset, ensuring smooth integration with the opencompass benchmarking framework.
3. Update `__init__.py` to upload wmt19 configs.

No major changes have been made to the existing framework structure. The new code strictly extends the dataset and inference capabilities without modifying any core components.

## BC-breaking (Optional)

This PR does not introduce any backward compatibility issues. The changes are self-contained within the new dataset and inference files and do not affect the existing functionality of the opencompass framework.

## Use cases (Optional)

This PR adds the WMT19 dataset to the opencompass framework. It can be used to evaluate large models on machine translation tasks, particularly between multiple language pairs supported by the WMT19 benchmark.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
