### PR TITLE
[Fix] Fix link-check workflow by adjusting line breaks in URL ignore patterns

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -10,12 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # - uses: actions/checkout@v3
-
-      - name: linkchecker
+  
+      - name: Install linkchecker
         run: |
           pip install linkchecker
-          linkchecker https://opencompass.readthedocs.io/ --no-robots -t 30 --no-warnings |
-            --ignore-url https://opencompass\.readthedocs\.io/.*/static/images/opencompass_logo\.svg |
-            --ignore-url https://opencompass\.readthedocs\.io/.*/_static/images/icon-menu-dots\.svg |
-            --ignore-url https://opencompass\.readthedocs\.io/policy |
-            --ignore-url https://opencompass\.readthedocs\.io/(en|zh_CN)/[0-9a-f]{40}/.*
+      
+
+      - name: Run linkchecker
+        run: |
+          linkchecker https://opencompass.readthedocs.io/ --no-robots -t 30 --no-warnings \
+            --ignore-url "https://opencompass.readthedocs.io/.*/static/images/opencompass_logo.svg" \
+            --ignore-url "https://opencompass.readthedocs.io/.*/_static/images/icon-menu-dots.svg" \
+            --ignore-url "https://opencompass.readthedocs.io/policy" \
+            --ignore-url "https://opencompass.readthedocs.io/(en|zh_CN)/[0-9a-f]{40}/.*"

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -5,6 +5,8 @@ on:
     # check links at 01:30 a.m. every day
     - cron: '30 1 * * *'
 
+  workflow_dispatch: # allow manual trigger
+
 jobs:
   link-check:
     runs-on: ubuntu-latest
@@ -14,7 +16,6 @@ jobs:
       - name: Install linkchecker
         run: |
           pip install linkchecker
-
 
       - name: Run linkchecker
         run: |

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # - uses: actions/checkout@v3
-  
+
       - name: Install linkchecker
         run: |
           pip install linkchecker
-      
+
 
       - name: Run linkchecker
         run: |


### PR DESCRIPTION
This pull request fixes the link-check workflow by resolving an issue where the `|` was mistakenly used for line breaks in the `ignore-url` patterns. The correct separator for line continuation is `\`. Additionally, the workflow now supports manual triggering with `workflow_dispatch`.

- Updated the `link-check` job to correctly install and run `linkchecker`.
- Fixed the `ignore-url` patterns by replacing `|` with `\` for correct line continuation in YAML.
- Added manual trigger capability with `workflow_dispatch`.