### PR TITLE
Bugfix-NPU-Support

### DIFF
--- a/opencompass/datasets/truthfulqa.py
+++ b/opencompass/datasets/truthfulqa.py
@@ -6,10 +6,17 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from opencompass.openicl.icl_evaluator import BaseEvaluator
 from opencompass.registry import ICL_EVALUATORS, LOAD_DATASET
+from mmengine.device import is_npu_available
 
 from .base import BaseDataset
 
-device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+if is_npu_available():
+    backend = 'npu'
+elif torch.cuda.is_available():
+    backend = 'cuda'
+else:
+    backend = 'cpu'
+device = torch.device(backend)
 
 
 @LOAD_DATASET.register_module()

--- a/opencompass/datasets/truthfulqa.py
+++ b/opencompass/datasets/truthfulqa.py
@@ -2,11 +2,11 @@ import evaluate
 import numpy as np
 import torch
 from datasets import load_dataset
+from mmengine.device import is_npu_available
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from opencompass.openicl.icl_evaluator import BaseEvaluator
 from opencompass.registry import ICL_EVALUATORS, LOAD_DATASET
-from mmengine.device import is_npu_available
 
 from .base import BaseDataset
 

--- a/opencompass/models/huggingface_above_v4_33.py
+++ b/opencompass/models/huggingface_above_v4_33.py
@@ -9,6 +9,7 @@ from opencompass.models.base_api import APITemplateParser
 from opencompass.registry import MODELS
 from opencompass.utils.logging import get_logger
 from opencompass.utils.prompt import PromptList
+from mmengine.device import is_npu_available
 
 PromptType = Union[PromptList, str]
 
@@ -224,6 +225,8 @@ class HuggingFacewithChatTemplate(BaseModel):
         model_kwargs.update(kwargs)
         model_kwargs = _set_model_kwargs_torch_dtype(model_kwargs)
         self.logger.debug(f'using model_kwargs: {model_kwargs}')
+        if is_npu_available():
+            model_kwargs['device_map'] = 'npu'
 
         try:
             self.model = AutoModelForCausalLM.from_pretrained(path, **model_kwargs)

--- a/opencompass/models/huggingface_above_v4_33.py
+++ b/opencompass/models/huggingface_above_v4_33.py
@@ -3,13 +3,13 @@
 from typing import Dict, List, Optional, Union
 
 import torch
+from mmengine.device import is_npu_available
 
 from opencompass.models.base import BaseModel, LMTemplateParser
 from opencompass.models.base_api import APITemplateParser
 from opencompass.registry import MODELS
 from opencompass.utils.logging import get_logger
 from opencompass.utils.prompt import PromptList
-from mmengine.device import is_npu_available
 
 PromptType = Union[PromptList, str]
 


### PR DESCRIPTION
# What does this PR do?

## Overview

This PR enables the users of `opencompass` to leverage the Ascend NPU for better performance in inferencing when GPU device is not available.

## Environment

- OS: ubuntu 20.04
- NPU: Atlas 300T A2
- CANN: 8.0.RC2
- torch-npu: 2.1.0
- torch: 2.1.0

Note

To properly install CANN, see [[here](https://ascend.github.io/docs/sources/ascend/quick_install.html)](https://ascend.github.io/docs/sources/ascend/quick_install.html) for more details.

In addition, The version of `torch-npu` should match that of `torch`, see [[here](https://github.com/Ascend/pytorch)](https://github.com/Ascend/pytorch) for more details.

## Bugs

In the NPU environment, the script from the Quick Start tutorial is supposed to run on the NPU device, but it is running on the CPU device instead. The scripts and error is as follows:

**Scripts:**

```bash
python run.py --models hf_internlm2_chat_1_8b hf_qwen2_1_5b_instruct 
			--datasets demo_gsm8k_chat_gen demo_math_chat_gen 
			--debug
```

**Error:**

```
Traceback (most recent call last):
  File "/home/lcg/github/opencompass/run.py", line 4, in <module>
    main()
  File "/home/lcg/github/opencompass/opencompass/cli/main.py", line 308, in main
    runner(tasks)
  File "/home/lcg/github/opencompass/opencompass/runners/base.py", line 38, in __call__
    status = self.launch(tasks)
  File "/home/lcg/github/opencompass/opencompass/runners/local.py", line 123, in launch
    task.run(cur_model=getattr(self, 'cur_model',
  File "/home/lcg/github/opencompass/opencompass/tasks/openicl_infer.py", line 89, in run
    self._inference()
  File "/home/lcg/github/opencompass/opencompass/tasks/openicl_infer.py", line 134, in _inference
    inferencer.inference(retriever,
  File "/home/lcg/github/opencompass/opencompass/openicl/icl_inferencer/icl_gen_inferencer.py", line 153, in inference
    results = self.model.generate_from_template(
  File "/home/lcg/github/opencompass/opencompass/models/base.py", line 201, in generate_from_template
    return self.generate(inputs, max_out_len=max_out_len, **kwargs)
  File "/home/lcg/github/opencompass/opencompass/models/huggingface_above_v4_33.py", line 476, in generate
    outputs = self.model.generate(**tokens, **generation_kwargs)
  File "/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/transformers/generation/utils.py", line 2047, in generate
    result = self._sample(
  File "/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/transformers/generation/utils.py", line 3007, in _sample
    outputs = self(**model_inputs, return_dict=True)
  File "/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/lcg/.cache/huggingface/modules/transformers_modules/internlm/internlm2-chat-1_8b/889898a85c5b880178a87e8c525acd5acb7a0096/modeling_internlm2.py", line 1212, in forward
    outputs = self.model(
  File "/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/lcg/.cache/huggingface/modules/transformers_modules/internlm/internlm2-chat-1_8b/889898a85c5b880178a87e8c525acd5acb7a0096/modeling_internlm2.py", line 1008, in forward
    layer_outputs = decoder_layer(
  File "/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/lcg/.cache/huggingface/modules/transformers_modules/internlm/internlm2-chat-1_8b/889898a85c5b880178a87e8c525acd5acb7a0096/modeling_internlm2.py", line 742, in forward
    hidden_states, self_attn_weights, present_key_value = self.attention(
  File "/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/lcg/.cache/huggingface/modules/transformers_modules/internlm/internlm2-chat-1_8b/889898a85c5b880178a87e8c525acd5acb7a0096/modeling_internlm2.py", line 312, in forward
    qkv_states = self.wqkv(hidden_states)
  File "/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/torch/nn/modules/linear.py", line 114, in forward
    return F.linear(input, self.weight, self.bias)
RuntimeError: "addmm_impl_cpu_" not implemented for 'Half'
```

Feel free to leave comments to guide me in further improvements 😊.

## Tests

**Scripts1:**

```bash
python run.py --models hf_internlm2_chat_1_8b hf_qwen2_1_5b_instruct 
			--datasets demo_gsm8k_chat_gen demo_math_chat_gen 
			--debug
```

**Log1:**

```
10/17 10:55:48 - OpenCompass - INFO - Loading example: configs/summarizers/example.py
10/17 10:55:48 - OpenCompass - INFO - Current exp folder: outputs/default/20241017_105548
10/17 10:55:48 - OpenCompass - WARNING - SlurmRunner is not used, so the partition argument is ignored.
10/17 10:55:48 - OpenCompass - INFO - Partitioned into 2 tasks.
10/17 10:55:50 - OpenCompass - INFO - Task [internlm2-chat-1.8b-hf/demo_gsm8k,internlm2-chat-1.8b-hf/demo_math]
Loading checkpoint shards: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:01<00:00,  1.02it/s]
10/17 10:57:35 - OpenCompass - INFO - using stop words: ['</s>', '<|im_end|>']
10/17 10:57:35 - OpenCompass - INFO - Try to load the data from /home/lcg/.cache/opencompass/./data/gsm8k/
10/17 10:57:35 - OpenCompass - INFO - Start inferencing [internlm2-chat-1.8b-hf/demo_gsm8k]
[2024-10-17 10:57:35,925] [opencompass.openicl.icl_inferencer.icl_gen_inferencer] [INFO] Starting build dataloader
[2024-10-17 10:57:35,925] [opencompass.openicl.icl_inferencer.icl_gen_inferencer] [INFO] Starting inference process...
  0%|                                                                                                                                                    | 0/8 [00:00<?, ?it/s][W VariableFallbackKernel.cpp:51] Warning: CAUTION: The operator 'aten::isin.Tensor_Tensor_out' is not currently supported on the NPU backend and will fall back to run on the CPU. This may have performance implications. (function npu_cpu_fallback)
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [01:31<00:00, 11.39s/it]
10/17 10:59:07 - OpenCompass - INFO - Try to load the data from /home/lcg/.cache/opencompass/./data/math/math.json
10/17 10:59:07 - OpenCompass - INFO - Start inferencing [internlm2-chat-1.8b-hf/demo_math]
[2024-10-17 10:59:07,186] [opencompass.openicl.icl_inferencer.icl_gen_inferencer] [INFO] Starting build dataloader
[2024-10-17 10:59:07,187] [opencompass.openicl.icl_inferencer.icl_gen_inferencer] [INFO] Starting inference process...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [08:35<00:00, 64.48s/it]
10/17 11:07:45 - OpenCompass - INFO - Task [qwen2-1.5b-instruct-hf/demo_gsm8k,qwen2-1.5b-instruct-hf/demo_math]
10/17 11:08:38 - OpenCompass - INFO - using stop words: ['<|im_end|>', '<|endoftext|>']
10/17 11:08:38 - OpenCompass - INFO - Try to load the data from /home/lcg/.cache/opencompass/./data/gsm8k/
10/17 11:08:39 - OpenCompass - INFO - Start inferencing [qwen2-1.5b-instruct-hf/demo_gsm8k]
[2024-10-17 11:08:39,100] [opencompass.openicl.icl_inferencer.icl_gen_inferencer] [INFO] Starting build dataloader
[2024-10-17 11:08:39,100] [opencompass.openicl.icl_inferencer.icl_gen_inferencer] [INFO] Starting inference process...
  0%|                                                                                                                                                    | 0/8 [00:00<?, ?it/s]/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/transformers/generation/configuration_utils.py:601: UserWarning: `do_sample` is set to `False`. However, `temperature` is set to `0.7` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.
  warnings.warn(
/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/transformers/generation/configuration_utils.py:606: UserWarning: `do_sample` is set to `False`. However, `top_p` is set to `0.8` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.
  warnings.warn(
/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/transformers/generation/configuration_utils.py:623: UserWarning: `do_sample` is set to `False`. However, `top_k` is set to `20` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.
  warnings.warn(
Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [09:32<00:00, 71.51s/it]
10/17 11:18:11 - OpenCompass - INFO - Try to load the data from /home/lcg/.cache/opencompass/./data/math/math.json
10/17 11:18:11 - OpenCompass - INFO - Start inferencing [qwen2-1.5b-instruct-hf/demo_math]
[2024-10-17 11:18:11,327] [opencompass.openicl.icl_inferencer.icl_gen_inferencer] [INFO] Starting build dataloader
[2024-10-17 11:18:11,327] [opencompass.openicl.icl_inferencer.icl_gen_inferencer] [INFO] Starting inference process...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [19:00<00:00, 142.53s/it]
10/17 11:37:11 - OpenCompass - INFO - Partitioned into 4 tasks.
10/17 11:37:13 - OpenCompass - INFO - Try to load the data from /home/lcg/.cache/opencompass/./data/gsm8k/
Parameter 'function'=<function OpenICLEvalTask._score.<locals>.postprocess at 0xffff68ff7760> of the transform datasets.arrow_dataset.Dataset._map_single couldn't be hashed properly, a random hash was used instead. Make sure your transforms and parameters are serializable with pickle or dill for the dataset fingerprinting and caching to work. If you reuse this transform, the caching mechanism will consider it to be different from the previous calls and recompute everything. This warning is only showed once. Subsequent hashing failures won't be showed.
Map: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 64/64 [00:00<00:00, 6288.31 examples/s]
10/17 11:37:14 - OpenCompass - INFO - Task [internlm2-chat-1.8b-hf/demo_gsm8k]: {'accuracy': 32.8125}
10/17 11:37:15 - OpenCompass - INFO - Try to load the data from /home/lcg/.cache/opencompass/./data/math/math.json
10/17 11:37:15 - OpenCompass - INFO - Task [internlm2-chat-1.8b-hf/demo_math]: {'accuracy': 14.0625}
10/17 11:37:17 - OpenCompass - INFO - Try to load the data from /home/lcg/.cache/opencompass/./data/gsm8k/
Map: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 64/64 [00:00<00:00, 6639.68 examples/s]
10/17 11:37:18 - OpenCompass - INFO - Task [qwen2-1.5b-instruct-hf/demo_gsm8k]: {'accuracy': 0.0}
10/17 11:37:20 - OpenCompass - INFO - Try to load the data from /home/lcg/.cache/opencompass/./data/math/math.json
10/17 11:37:20 - OpenCompass - INFO - Task [qwen2-1.5b-instruct-hf/demo_math]: {'accuracy': 0.0}
dataset     version    metric    mode      internlm2-chat-1.8b-hf    qwen2-1.5b-instruct-hf
----------  ---------  --------  ------  ------------------------  ------------------------
demo_gsm8k  1d7fe4     accuracy  gen                        32.81                      0.00
demo_math   393424     accuracy  gen                        14.06                      0.00
10/17 11:37:20 - OpenCompass - INFO - write summary to /home/lcg/github/opencompass/outputs/default/20241017_105548/summary/summary_20241017_105548.txt
10/17 11:37:20 - OpenCompass - INFO - write csv to /home/lcg/github/opencompass/outputs/default/20241017_105548/summary/summary_20241017_105548.csv
```

**Scripts2:**

```bash
python run.py configs/eval_chat_demo.py -w outputs/demo --debug
```

**Log2:**

```
  0%|                                                                                                                                                    | 0/8 [00:00<?, ?it/s]/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/transformers/generation/configuration_utils.py:601: UserWarning: `do_sample` is set to `False`. However, `temperature` is set to `0.7` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.
  warnings.warn(
/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/transformers/generation/configuration_utils.py:606: UserWarning: `do_sample` is set to `False`. However, `top_p` is set to `0.8` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.
  warnings.warn(
/home/lcg/miniconda3/envs/opencompass/lib/python3.10/site-packages/transformers/generation/configuration_utils.py:623: UserWarning: `do_sample` is set to `False`. However, `top_k` is set to `20` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.
  warnings.warn(
[W VariableFallbackKernel.cpp:51] Warning: CAUTION: The operator 'aten::isin.Tensor_Tensor_out' is not currently supported on the NPU backend and will fall back to run on the CPU. This may have performance implications. (function npu_cpu_fallback)
Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [04:47<00:00, 35.98s/it]
10/17 11:59:15 - OpenCompass - INFO - Try to load the data from /home/lcg/.cache/opencompass/./data/math/math.json
10/17 11:59:15 - OpenCompass - INFO - Start inferencing [qwen2-1.5b-instruct-hf/demo_math]
[2024-10-17 11:59:15,136] [opencompass.openicl.icl_inferencer.icl_gen_inferencer] [INFO] Starting build dataloader
[2024-10-17 11:59:15,137] [opencompass.openicl.icl_inferencer.icl_gen_inferencer] [INFO] Starting inference process...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [10:25<00:00, 78.18s/it]
10/17 12:09:42 - OpenCompass - INFO - Task [internlm2-chat-1.8b-hf/demo_gsm8k,internlm2-chat-1.8b-hf/demo_math]
Loading checkpoint shards: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:02<00:00,  1.02s/it]
10/17 12:11:27 - OpenCompass - INFO - using stop words: ['<|im_end|>', '</s>']
10/17 12:11:27 - OpenCompass - INFO - Try to load the data from /home/lcg/.cache/opencompass/./data/gsm8k/
10/17 12:11:27 - OpenCompass - INFO - Start inferencing [internlm2-chat-1.8b-hf/demo_gsm8k]
[2024-10-17 12:11:27,625] [opencompass.openicl.icl_inferencer.icl_gen_inferencer] [INFO] Starting build dataloader
[2024-10-17 12:11:27,625] [opencompass.openicl.icl_inferencer.icl_gen_inferencer] [INFO] Starting inference process...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [02:44<00:00, 20.60s/it]
10/17 12:14:12 - OpenCompass - INFO - Try to load the data from /home/lcg/.cache/opencompass/./data/math/math.json
10/17 12:14:12 - OpenCompass - INFO - Start inferencing [internlm2-chat-1.8b-hf/demo_math]
[2024-10-17 12:14:12,542] [opencompass.openicl.icl_inferencer.icl_gen_inferencer] [INFO] Starting build dataloader
[2024-10-17 12:14:12,542] [opencompass.openicl.icl_inferencer.icl_gen_inferencer] [INFO] Starting inference process...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [13:58<00:00, 104.78s/it]
10/17 12:28:10 - OpenCompass - INFO - Partitioned into 4 tasks.
10/17 12:28:12 - OpenCompass - INFO - Try to load the data from /home/lcg/.cache/opencompass/./data/gsm8k/
Parameter 'function'=<function OpenICLEvalTask._score.<locals>.postprocess at 0xffff4a5a76d0> of the transform datasets.arrow_dataset.Dataset._map_single couldn't be hashed properly, a random hash was used instead. Make sure your transforms and parameters are serializable with pickle or dill for the dataset fingerprinting and caching to work. If you reuse this transform, the caching mechanism will consider it to be different from the previous calls and recompute everything. This warning is only showed once. Subsequent hashing failures won't be showed.
Map: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 64/64 [00:00<00:00, 6343.59 examples/s]
10/17 12:28:13 - OpenCompass - INFO - Task [qwen2-1.5b-instruct-hf/demo_gsm8k]: {'accuracy': 0.0}
10/17 12:28:14 - OpenCompass - INFO - Try to load the data from /home/lcg/.cache/opencompass/./data/math/math.json
10/17 12:28:14 - OpenCompass - INFO - Task [qwen2-1.5b-instruct-hf/demo_math]: {'accuracy': 0.0}
10/17 12:28:16 - OpenCompass - INFO - Try to load the data from /home/lcg/.cache/opencompass/./data/gsm8k/
Map: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 64/64 [00:00<00:00, 6306.93 examples/s]
10/17 12:28:17 - OpenCompass - INFO - Task [internlm2-chat-1.8b-hf/demo_gsm8k]: {'accuracy': 32.8125}
10/17 12:28:19 - OpenCompass - INFO - Try to load the data from /home/lcg/.cache/opencompass/./data/math/math.json
10/17 12:28:19 - OpenCompass - INFO - Task [internlm2-chat-1.8b-hf/demo_math]: {'accuracy': 14.0625}
dataset     version    metric    mode      qwen2-1.5b-instruct-hf    internlm2-chat-1.8b-hf
----------  ---------  --------  ------  ------------------------  ------------------------
demo_gsm8k  1d7fe4     accuracy  gen                         0.00                     32.81
demo_math   393424     accuracy  gen                         0.00                     14.06
10/17 12:28:19 - OpenCompass - INFO - write summary to /home/lcg/github/opencompass/outputs/demo/20241017_115332/summary/summary_20241017_115332.txt
10/17 12:28:19 - OpenCompass - INFO - write csv to /home/lcg/github/opencompass/outputs/demo/20241017_115332/summary/summary_20241017_115332.csv
```