### PR TITLE
Add single lora adapter support for vLLM inference.

### DIFF
--- a/opencompass/models/vllm.py
+++ b/opencompass/models/vllm.py
@@ -7,6 +7,7 @@ from opencompass.utils import get_logger
 
 try:
     from vllm import LLM, SamplingParams
+    from vllm.lora.request import LoRARequest
 except ImportError:
     LLM, SamplingParams = None, None
 
@@ -25,6 +26,7 @@ class VLLM(BaseModel):
         meta_template: Optional[Dict] = None,
         mode: str = 'none',
         use_fastchat_template: bool = False,
+        lora_path: str = None,
         stop_words: List[str] = [],
     ):
         super().__init__(path=path,
@@ -38,7 +40,7 @@ class VLLM(BaseModel):
         self.tokenizer = self.model.get_tokenizer()
         self.generation_kwargs = generation_kwargs
         self.generation_kwargs.pop('do_sample', None)
-
+        self.lora_path = lora_path
         assert mode in ['none', 'mid']
         self.mode = mode
         self.use_fastchat_template = use_fastchat_template
@@ -96,7 +98,10 @@ class VLLM(BaseModel):
         _stop = list(set(self.stop_words + stopping_criteria))
         generation_kwargs.update({'stop': _stop})
         sampling_kwargs = SamplingParams(**generation_kwargs)
-        outputs = self.model.generate(inputs, sampling_kwargs)
+        if not self.lora_path:
+            outputs = self.model.generate(inputs, sampling_kwargs)
+        else:
+            outputs = self.model.generate(inputs, sampling_kwargs, lora_request=LoRARequest("sql_adapter", 1, self.lora_path))
 
         prompt_list, output_strs = [], []
         for output in outputs:


### PR DESCRIPTION
## Motivation

When evaluating SFT/DPO trained models, vLLM accelerated inference with a single LoRA adapter is often used, but this feature isn’t supported in the source code. Therefore, I added a few lines of code to enable this simple functionality.

## Modification

Added a lora_path in opencompass/models/vllm.py and utilized it during generate.

## Use cases (Optional)

Now we can use LoRA vLLM inference as shown in the code below.

models = [
    dict(
        type=VLLM,
        abbr='Llama3_8B_LoRA_SFT',
        path='llama-3-8b-instruct',
        model_kwargs=dict(tensor_parallel_size=2, dtype='bfloat16', seed=0, max_model_len=4096, enable_lora=True,),
        max_out_len=100,
        max_seq_len=4096,
        batch_size=32,
        lora_path="Llama3_8B_LoRA_checkpoints/checkpoint-1250/",
        generation_kwargs=dict(temperature=0.0, top_p=0.8, max_tokens=1024,),
        stop_words=['<|end_of_text|>', '<|eot_id|>'],
        run_cfg=dict(num_gpus=2),
    )
]