### PR TITLE
[Update] update volc CPU flavor

### DIFF
--- a/opencompass/runners/volc.py
+++ b/opencompass/runners/volc.py
@@ -249,7 +249,7 @@ class VOLCRunner(BaseRunner):
         with open(config_path) as fp:
             volc_cfg = yaml.safe_load(fp)
         if num_gpus <= 0:
-            flavor = 'ml.c1ie.2xlarge'
+            flavor = 'ml.c3i.2xlarge'
         elif num_gpus == 1:
             flavor = 'ml.pni2l.3xlarge'
         elif num_gpus == 2:


### PR DESCRIPTION
Update volc CPU flavor. Use `ml.c3i.2xlarge` instead of  `ml.c1ie.2xlarge`.