### PR TITLE
[Update] Update requirement and deepseek configurations

### DIFF
--- a/opencompass/configs/models/deepseek/lmdeploy_deepseek_v2_5_1210.py
+++ b/opencompass/configs/models/deepseek/lmdeploy_deepseek_v2_5_1210.py
@@ -3,8 +3,8 @@ from opencompass.models import TurboMindModelwithChatTemplate
 models = [
     dict(
         type=TurboMindModelwithChatTemplate,
-        abbr='deepseek-v2_5-turbomind',
-        path='deepseek-ai/DeepSeek-V2.5',
+        abbr='deepseek-v2_5-1210-turbomind',
+        path='deepseek-ai/DeepSeek-V2.5-1210',
         backend='pytorch',
         engine_config=dict(
             session_len=7168,

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -8,6 +8,7 @@ func_timeout
 fuzzywuzzy
 gradio-client
 h5py
+httpx==0.27.2
 huggingface_hub<=0.24.7
 immutabledict
 importlib-metadata


### PR DESCRIPTION
1. Fix httpx version (requireded by BigCodebench)
2. Update Deepseek V2.5 default backend