### PR TITLE
[Fix] Fix Local Runner Params Save Path

### DIFF
--- a/opencompass/models/openai_api.py
+++ b/opencompass/models/openai_api.py
@@ -147,7 +147,7 @@ class OpenAI(BaseAPIModel):
         self.path = path
         self.max_completion_tokens = max_completion_tokens
         self.logger.warning(
-            f'Max Completion tokens for {path} is :{max_completion_tokens}')
+            f'Max Completion tokens for {path} is {max_completion_tokens}')
 
     def generate(self,
                  inputs: List[PromptType],
@@ -278,7 +278,7 @@ class OpenAI(BaseAPIModel):
                     self.logger.warning(
                         f"'max_token' is unsupported for model {self.path}")
                     self.logger.warning(
-                        f'We use max_completion_tokens:'
+                        f'We use max_completion_tokens: '
                         f'{self.max_completion_tokens}for this query')
                     data = dict(
                         model=self.path,
@@ -588,13 +588,12 @@ class OpenAISDK(OpenAI):
                 self.logger.warning(
                     f"'max_token' is unsupported for model {self.path}")
                 self.logger.warning(
-                    f'We use max_completion_tokens:'
+                    f'We use max_completion_tokens: '
                     f'{self.max_completion_tokens}for this query')
                 query_data = dict(
                     model=self.path,
                     max_completion_tokens=self.max_completion_tokens,
                     n=1,
-                    temperature=self.temperature,
                     messages=messages,
                     extra_body=self.extra_body,
                 )
@@ -636,8 +635,8 @@ class OpenAISDK(OpenAI):
                 if (status_code is not None
                         and status_code in self.status_code_mappings):
                     error_message = self.status_code_mappings[status_code]
-                    self.logger.info(f'Status Code: {status_code},\n'
-                                     f'Original Error Message: {e},\n'
+                    self.logger.info(f'Status Code: {status_code}, \n'
+                                     f'Original Error Message: {e}, \n'
                                      f'Return Message: {error_message} ')
                     return error_message
                 else:

--- a/opencompass/runners/local.py
+++ b/opencompass/runners/local.py
@@ -207,11 +207,13 @@ class LocalRunner(BaseRunner):
 
         task_name = task.name
 
+        pwd = os.getcwd()
         # Dump task config to file
-        params_file_dir = os.path.join(task.cfg.work_dir, 'params')
-        mmengine.mkdir_or_exist(params_file_dir)
-        param_file = os.path.join(params_file_dir,
-                                  f'{os.getpid()}_{index}_params.py')
+        mmengine.mkdir_or_exist('tmp/')
+        # Using uuid to avoid filename conflict
+        import uuid
+        uuid_str = str(uuid.uuid4())
+        param_file = f'{pwd}/tmp/{uuid_str}_params.py'
 
         try:
             task.cfg.dump(param_file)
@@ -239,6 +241,8 @@ class LocalRunner(BaseRunner):
                 logger.error(f'task {task_name} fail, see\n{out_path}')
         finally:
             # Clean up
-            if os.path.exists(param_file):
+            if not self.keep_tmp_file:
                 os.remove(param_file)
+            else:
+                pass
         return task_name, result.returncode

--- a/opencompass/runners/local.py
+++ b/opencompass/runners/local.py
@@ -1,6 +1,7 @@
 import os
 import os.path as osp
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -208,8 +209,11 @@ class LocalRunner(BaseRunner):
         task_name = task.name
 
         # Dump task config to file
-        mmengine.mkdir_or_exist('tmp/')
-        param_file = f'tmp/{os.getpid()}_{index}_params.py'
+        params_file_dir = os.path.join(task.cfg.work_dir, 'params')
+        mmengine.mkdir_or_exist(params_file_dir)
+        param_file = os.path.join(params_file_dir,
+                                  f'{os.getpid()}_{index}_params.py')
+
         try:
             task.cfg.dump(param_file)
             tmpl = get_command_template(gpu_ids)
@@ -236,5 +240,6 @@ class LocalRunner(BaseRunner):
                 logger.error(f'task {task_name} fail, see\n{out_path}')
         finally:
             # Clean up
-            os.remove(param_file)
+            if os.path.exists(param_file):
+                shutil.rmtree(params_file_dir)
         return task_name, result.returncode

--- a/opencompass/runners/local.py
+++ b/opencompass/runners/local.py
@@ -240,5 +240,5 @@ class LocalRunner(BaseRunner):
         finally:
             # Clean up
             if os.path.exists(param_file):
-                os.remove(params_file_dir)
+                os.remove(param_file)
         return task_name, result.returncode

--- a/opencompass/runners/local.py
+++ b/opencompass/runners/local.py
@@ -1,7 +1,6 @@
 import os
 import os.path as osp
 import re
-import shutil
 import subprocess
 import sys
 import time
@@ -241,5 +240,5 @@ class LocalRunner(BaseRunner):
         finally:
             # Clean up
             if os.path.exists(param_file):
-                shutil.rmtree(params_file_dir)
+                os.remove(params_file_dir)
         return task_name, result.returncode


### PR DESCRIPTION
## Motivation

When multiple tasks are submitted in the cloud server's shared file system, the existing local_runner's logic for saving params.py files can cause conflicts between different tasks (these tasks may have the same pid).

## Modification

Modify the save path of params.py to work dir of each task.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.
