### PR TITLE
[Feature] Support MMLU-CF Benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Just like a compass guides us on our journey, OpenCompass will guide you through
 
 ## 🚀 What's New <a><img width="35" height="20" src="https://user-images.githubusercontent.com/12782558/212848161-5e783dd6-11e8-4fe0-bbba-39ffb77730be.png"></a>
 
+
+- **\[2024.12.24\]** We now support the Microsoft's Contamination-Free Multi-task language Understanding Benchmark [MMLU-CF](https://huggingface.co/datasets/microsoft/MMLU-CF). Feel free to give it a try! 🔥🔥🔥
+
 - **\[2024.12.17\]** We have provided the evaluation script for the December [CompassAcademic](configs/eval_academic_leaderboard_202412.py), which allows users to easily reproduce the official evaluation results by configuring it.
 - **\[2024.11.14\]** OpenCompass now offers support for a sophisticated benchmark designed to evaluate complex reasoning skills — [MuSR](https://arxiv.org/pdf/2310.16049). Check out the [demo](configs/eval_musr.py) and give it a spin! 🔥🔥🔥
 - **\[2024.11.14\]** OpenCompass now supports the brand new long-context language model evaluation benchmark — [BABILong](https://arxiv.org/pdf/2406.10149). Have a look at the [demo](configs/eval_babilong.py) and give it a try! 🔥🔥🔥

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -57,6 +57,7 @@
 
 ## 🚀 最新进展 <a><img width="35" height="20" src="https://user-images.githubusercontent.com/12782558/212848161-5e783dd6-11e8-4fe0-bbba-39ffb77730be.png"></a>
 
+- **\[2024.12.24\]** 现已支持Microsoft去污染多任务语言理解数据集[MMLU-CF](https://huggingface.co/datasets/microsoft/MMLU-CF)，欢迎尝试! 🔥🔥🔥
 - **\[2024.12.17\]** 我们提供了12月CompassAcademic学术榜单评估脚本 [CompassAcademic](configs/eval_academic_leaderboard_202412.py)，你可以通过简单地配置复现官方评测结果。
 - **\[2024.10.14\]** 现已支持OpenAI多语言问答数据集[MMMLU](https://huggingface.co/datasets/openai/MMMLU)，欢迎尝试! 🔥🔥🔥
 - **\[2024.09.19\]** 现已支持[Qwen2.5](https://huggingface.co/Qwen)(0.5B to 72B) ，可以使用多种推理后端(huggingface/vllm/lmdeploy), 欢迎尝试! 🔥🔥🔥

--- a/configs/dataset_collections/chat_OC15.py
+++ b/configs/dataset_collections/chat_OC15.py
@@ -2,6 +2,7 @@ from mmengine.config import read_base
 
 with read_base():
     from opencompass.configs.datasets.mmlu.mmlu_gen_4d595a import mmlu_datasets
+    from opencompass.configs.datasets.mmlu_cf.mmlu_cf_gen  import mmlu_cf_datasets
     from opencompass.configs.datasets.cmmlu.cmmlu_gen_c13365 import cmmlu_datasets
     from opencompass.configs.datasets.ceval.ceval_gen_5f30c7 import ceval_datasets
     from opencompass.configs.datasets.GaokaoBench.GaokaoBench_no_subjective_gen_4c31db import GaokaoBench_datasets

--- a/configs/datasets/mmlu_cf/README.md
+++ b/configs/datasets/mmlu_cf/README.md
@@ -1,0 +1,614 @@
+# MMLU-CF: A Contamination-free Multi-task Language Understanding Benchmark
+
+<div align="center">
+
+![](https://img.shields.io/badge/Task-MMLU_CF-orange)
+![](https://img.shields.io/badge/Data-Released-green)
+![](https://img.shields.io/badge/Code_License-MIT-blue)
+
+</div>
+
+<p align="center">
+  <a href="https://arxiv.org/pdf/2412.15194"><b>[📜 Paper]</b></a> •
+  <a href="https://huggingface.co/datasets/microsoft/MMLU-CF"><b>[🤗 HF Dataset]</b></a> •
+  <a href="https://github.com/microsoft/MMLU-CF"><b>[🐱 GitHub]</b></a>
+</p>
+
+## 📢 News and Updates
+[2024.12.01] 🔥We have initialized the repository.  
+[2024.12.16] 🔥We have added the evaluation results of Phi-4-14B and Llama-3.3-70B-Instruct.  
+[2024.12.20] 🔥We have released the validation dataset of MMLU-CF.  
+
+
+## 1. The Motivation of MMLU-CF
+
+<!-- MMLU-CF is a contamination-free and more challenging multiple-choice question benchmark. This dataset contains 10K questions each for the validation set and test set, covering various disciplines. -->
+
+- The open-source nature of these benchmarks and the broad sources of training data for LLMs have inevitably led to benchmark contamination, resulting in unreliable evaluation results. To alleviate this issue, we propose MMLU-CF.
+- (a) An instance of leakage in MMLU. When questions are used as prompt from the MMLU, certain LLMs, due to their memorization capabilities, directly provide **choices identical to the original ones**. (b) When questions are used as prompt from the MMLU-CF, LLMs only provide guessed choices.
+This indicates that the MMLU test set suffers from data contamination and memorization by some LLMs, while the proposed MMLU-CF avoids such leakage.
+<p float="center">
+  <img src="./Figures/Fig_1_a.png" alt="Fig1_a" width="45%" />
+  <img src="./Figures/Fig_1_b.png" alt="Fig1_b" width="45%" />
+</p>
+
+
+## 2. How to Evaluate Your Models on the MMLU-CF Validation/Test Set
+
+  #### (1) We perform automated testing only on Huggingface models. After following the steps outlined below and obtaining the validation set results from [OpenCompass](https://github.com/open-compass/opencompass), the test set results can then be accessed via GitHub Issues. 
+  
+  **Step 1**. **Validation set evaluation**: Obtaining the validation results for your model using LLM evaluation tools, [OpenCompass](https://github.com/open-compass/opencompass). The validation dataset download from [🤗 Huggingface](https://huggingface.co/datasets/microsoft/MMLU-CF). The data directory structure in the opencompass:
+
+```
+data
+└── mmlu_cf 
+    ├── dev
+    └── val
+```
+  
+  **Step 2**. **Test set evaluation**: With the validation results, submit a GitHub issue on the [MMLU-CF](https://github.com/) GitHub homepage to request the test set results. Please follow the format below:
+
+Example 1,
+```
+Title: 
+Test set evaluation Request - add HF model [microsoft/phi-4]  
+Content: 
+The result on validation set: 68.5%
+```
+Example 2,
+<p>
+  <img src="./Figures/Fig_6.png" alt="Fig6" width="80%" style="display: block; margin: 0 auto;" />
+</p>
+
+  **Notably**:
+   - Ensure you use the format with square brackets `[ ]` as shown. The model name **microsoft/phi-4** corresponds to the name on HuggingFace.
+   - We will automatically submit your model. The time to receive the results depends on the number of models being evaluated, but it typically takes **1-2 weeks**.
+
+  #### (2) For API models, if OpenCompass updates the model interface, you can obtain the test set results by sending a temporary key to [Email](yangyu.huang@microsoft.com) after receiving the validation set results.
+
+
+## 3. What is the Difference between MMLU-CF and MMLU
+MMLU focuses on the breadth and reasoning without considering contamination prevention. We apply three decontamination rules to mitigate unintentional data leakage while collecting data from a broader domain. Meanwhile, our MMLU-CF benchmark maintains the test set closed-source to prevent malicious data leakage.
+
+<p float="left">
+  <img src="./Figures/Fig_4.png" alt="Fig4" width="55%" />
+  <span style="display:inline-block; width: 10%;"></span>
+  <img src="./Figures/Fig_5.png" alt="Fig5" width="30%" />
+</p>
+
+
+## 4. Leaderboard
+<table>
+  <thead>
+    <tr>
+      <th rowspan="2">Model</th>
+      <th colspan="1">MMLU </th>
+      <th colspan="6">MMLU-CF </th>
+    </tr>
+    <tr>
+      <th>5-shot   </th>
+      <th>5-shot Test   </th>
+      <th>5-shot Validation  </th>
+      <th>5-shot Δ   </th>
+      <th>0-shot Test   </th>
+      <th>0-shot Validation    </th>
+      <th>0-shot Δ    </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>API</strong></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>GPT-4o</td>
+      <td>88.0</td>
+      <td>73.4</td>
+      <td>73.4</td>
+      <td>+0.0</td>
+      <td>71.9</td>
+      <td>72.4</td>
+      <td>-0.5</td>
+    </tr>
+    <tr>
+      <td>GPT-4-Turbo</td>
+      <td>86.5</td>
+      <td>70.4</td>
+      <td>70.1</td>
+      <td>+0.3</td>
+      <td>68.9</td>
+      <td>68.7</td>
+      <td>+0.1</td>
+    </tr>
+    <tr>
+      <td>GPT-4o-mini</td>
+      <td>81.8</td>
+      <td>65.5</td>
+      <td>65.1</td>
+      <td>+0.4</td>
+      <td>66.0</td>
+      <td>65.3</td>
+      <td>+0.7</td>
+    </tr>
+    <tr>
+      <td>Gemini-1.5-Flash</td>
+      <td>78.7</td>
+      <td>64.8</td>
+      <td>64.9</td>
+      <td>-0.1</td>
+      <td>56.7</td>
+      <td>56.9</td>
+      <td>-0.2</td>
+    </tr>
+    <tr>
+      <td>GPT-3.5-Turbo</td>
+      <td>71.4</td>
+      <td>58.2</td>
+      <td>59.0</td>
+      <td>-0.8</td>
+      <td>57.2</td>
+      <td>58.1</td>
+      <td>-0.9</td>
+    </tr>
+    <tr>
+      <td><strong>Large</strong></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Qwen2.5-72B-instruct</td>
+      <td>85.3</td>
+      <td>71.6</td>
+      <td>71.3</td>
+      <td>+0.3</td>
+      <td>70.6</td>
+      <td>70.4</td>
+      <td>+0.2</td>
+    </tr>
+    <tr>
+      <td>Llama-3-70B-instruct</td>
+      <td>82.0</td>
+      <td>68.9</td>
+      <td>68.8</td>
+      <td>+0.1</td>
+      <td>68.1</td>
+      <td>67.4</td>
+      <td>+0.7</td>
+    </tr>
+    <tr>
+      <td>Llama-3.3-70B-instruct</td>
+      <td>86.3</td>
+      <td>68.8</td>
+      <td>67.8</td>
+      <td>+1.0</td>
+      <td>67.6</td>
+      <td>67.5</td>
+      <td>+0.1</td>
+    </tr>
+    <tr>
+      <td>Llama-3.1-70B-instruct</td>
+      <td>86.0</td>
+      <td>68.7</td>
+      <td>68.1</td>
+      <td>+0.6</td>
+      <td>70.4</td>
+      <td>69.7</td>
+      <td>+0.7</td>
+    </tr>
+    <tr>
+      <td>Phi-3.5-MoE-instruct</td>
+      <td>78.9</td>
+      <td>64.6</td>
+      <td>64.5</td>
+      <td>+0.1</td>
+      <td>63.1</td>
+      <td>62.1</td>
+      <td>+1.0</td>
+    </tr>
+    <tr>
+      <td>Qwen2-72B-instruct</td>
+      <td>82.3</td>
+      <td>63.7</td>
+      <td>64.3</td>
+      <td>-0.6</td>
+      <td>62.4</td>
+      <td>62.5</td>
+      <td>-0.1</td>
+    </tr>
+    <tr>
+      <td>Mixtral-8x22B-instruct</td>
+      <td>76.2</td>
+      <td>62.8</td>
+      <td>62.5</td>
+      <td>+0.3</td>
+      <td>65.3</td>
+      <td>64.8</td>
+      <td>+0.5</td>
+    </tr>
+    <tr>
+  <td>Qwen1.5-72B-chat</td>
+  <td>75.6</td>
+  <td>59.8</td>
+  <td>60.2</td>
+  <td>-0.4</td>
+  <td>59.1</td>
+  <td>59.6</td>
+  <td>-0.5</td>
+</tr>
+<tr>
+  <td>Llama-2-70B-chat</td>
+  <td>68.9</td>
+  <td>52.2</td>
+  <td>51.8</td>
+  <td>+0.4</td>
+  <td>51.2</td>
+  <td>50.9</td>
+  <td>+0.3</td>
+</tr>
+<tr>
+  <td><strong>Medium</strong></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+</tr>
+<tr>
+  <td>Qwen2.5-32B-instruct</td>
+  <td>83.9</td>
+  <td>69.7</td>
+  <td>68.8</td>
+  <td>+0.9</td>
+  <td>68.9</td>
+  <td>68.8</td>
+  <td>+0.1</td>
+</tr>
+<tr>
+  <td>Phi-4-14B</td>
+  <td>84.8</td>
+  <td>67.8</td>
+  <td>68.5</td>
+  <td>-0.7</td>
+  <td>68.5</td>
+  <td>69.4</td>
+  <td>-0.9</td>
+</tr>
+<tr>
+  <td>Qwen2.5-14B-instruct</td>
+  <td>79.9</td>
+  <td>66.4</td>
+  <td>66.1</td>
+  <td>+0.3</td>
+  <td>67.0</td>
+  <td>66.0</td>
+  <td>+1.0</td>
+</tr>
+<tr>
+  <td>Phi-3-medium-instruct</td>
+  <td>77.9</td>
+  <td>64.2</td>
+  <td>64.2</td>
+  <td>+0.0</td>
+  <td>62.5</td>
+  <td>62.7</td>
+  <td>-0.2</td>
+</tr>
+<tr>
+  <td>Gemma2-27B</td>
+  <td>75.2</td>
+  <td>63.9</td>
+  <td>63.5</td>
+  <td>+0.4</td>
+  <td>64.2</td>
+  <td>64.0</td>
+  <td>+0.2</td>
+</tr>
+<tr>
+  <td>Yi-1.5-34B-chat</td>
+  <td>76.8</td>
+  <td>61.3</td>
+  <td>60.5</td>
+  <td>+0.8</td>
+  <td>60.6</td>
+  <td>59.5</td>
+  <td>+1.1</td>
+</tr>
+<tr>
+  <td>Mixtral-8x7B-instruct-v0.1</td>
+  <td>70.5</td>
+  <td>58.3</td>
+  <td>57.1</td>
+  <td>-1.2</td>
+  <td>58.9</td>
+  <td>58.5</td>
+  <td>+0.4</td>
+</tr>
+<tr>
+  <td>Deepseek-v2-lite-chat</td>
+  <td>55.7</td>
+  <td>49.3</td>
+  <td>48.7</td>
+  <td>+0.6</td>
+  <td>48.2</td>
+  <td>47.7</td>
+  <td>+0.5</td>
+</tr>
+<tr>
+  <td>Baichuan-2-13B-chat</td>
+  <td>57.3</td>
+  <td>48.3</td>
+  <td>48.6</td>
+  <td>-0.3</td>
+  <td>47.1</td>
+  <td>48.1</td>
+  <td>-1.0</td>
+</tr>
+<tr>
+  <td>Llama-2-13B-chat</td>
+  <td>54.8</td>
+  <td>42.8</td>
+  <td>42.1</td>
+  <td>+0.7</td>
+  <td>44.8</td>
+  <td>44.6</td>
+  <td>+0.2</td>
+</tr>
+<tr>
+  <td><strong>Small</strong></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+</tr>
+<tr>
+  <td>Qwen2.5-7B-instruct</td>
+  <td>75.4</td>
+  <td>61.3</td>
+  <td>60.4</td>
+  <td>+0.9</td>
+  <td>59.3</td>
+  <td>58.6</td>
+  <td>+0.7</td>
+</tr>
+<tr>
+  <td>Qwen2-7B-instruct</td>
+  <td>70.5</td>
+  <td>58.1</td>
+  <td>57.9</td>
+  <td>+0.2</td>
+  <td>58.3</td>
+  <td>57.4</td>
+  <td>+0.9</td>
+</tr>
+<tr>
+  <td>Glm-4-9B-chat</td>
+  <td>72.4</td>
+  <td>57.8</td>
+  <td>57.9</td>
+  <td>-0.1</td>
+  <td>58.6</td>
+  <td>58.7</td>
+  <td>-0.1</td>
+</tr>
+<tr>
+  <td>Internlm-2.5-7B-chat</td>
+  <td>72.8</td>
+  <td>57.3</td>
+  <td>56.8</td>
+  <td>+0.5</td>
+  <td>57.9</td>
+  <td>56.9</td>
+  <td>+1.0</td>
+</tr>
+<tr>
+  <td>Llama-3-8B-instruct</td>
+  <td>68.4</td>
+  <td>57.3</td>
+  <td>56.5</td>
+  <td>+0.8</td>
+  <td>56.4</td>
+  <td>55.4</td>
+  <td>+1.0</td>
+</tr>
+<tr>
+  <td>Llama-3.1-8B-instruct</td>
+  <td>68.1</td>
+  <td>57.1</td>
+  <td>57.9</td>
+  <td>-0.8</td>
+  <td>56.1</td>
+  <td>56.1</td>
+  <td>+0.0</td>
+</tr>
+<tr>
+  <td>Gemma-2-9B</td>
+  <td>71.3</td>
+  <td>53.7</td>
+  <td>53.3</td>
+  <td>+0.4</td>
+  <td>32.1</td>
+  <td>31.2</td>
+  <td>+0.9</td>
+</tr>
+<tr>
+  <td>Yi-1.5-6B-chat</td>
+  <td>62.8</td>
+  <td>52.8</td>
+  <td>51.4</td>
+  <td>+1.4</td>
+  <td>52.2</td>
+  <td>51.9</td>
+  <td>+0.3</td>
+</tr>
+<tr>
+  <td>Mistral-7B-instruct-v0.3</td>
+  <td>60.3</td>
+  <td>50.7</td>
+  <td>50.9</td>
+  <td>-0.2</td>
+  <td>51.1</td>
+  <td>50.9</td>
+  <td>+0.2</td>
+</tr>
+<tr>
+  <td>Baichuan-2-7B-chat</td>
+  <td>52.9</td>
+  <td>44.5</td>
+  <td>43.9</td>
+  <td>+0.6</td>
+  <td>43.9</td>
+  <td>44.0</td>
+  <td>-0.1</td>
+</tr>
+<tr>
+  <td>Llama-2-7B-chat</td>
+  <td>45.3</td>
+  <td>39.4</td>
+  <td>38.5</td>
+  <td>+0.9</td>
+  <td>41.9</td>
+  <td>40.9</td>
+  <td>+1.0</td>
+</tr>
+<tr>
+  <td><strong>Mini</strong></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+</tr>
+<tr>
+  <td>Phi-3-mini-instruct (3.8B)</td>
+  <td>70.9</td>
+  <td>57.9</td>
+  <td>58.1</td>
+  <td>-0.2</td>
+  <td>58.2</td>
+  <td>57.5</td>
+  <td>+0.7</td>
+</tr>
+<tr>
+  <td>Phi-3.5-mini-instruct (3.8B)</td>
+  <td>69.1</td>
+  <td>57.9</td>
+  <td>57.4</td>
+  <td>+0.5</td>
+  <td>58.3</td>
+  <td>57.7</td>
+  <td>+0.6</td>
+</tr>
+<tr>
+  <td>Qwen2.5-3B-instruct</td>
+  <td>64.4</td>
+  <td>55.9</td>
+  <td>56.4</td>
+  <td>-0.5</td>
+  <td>54.3</td>
+  <td>53.9</td>
+  <td>+0.4</td>
+</tr>
+<tr>
+  <td>Qwen2.5-1.5B-instruct</td>
+  <td>50.7</td>
+  <td>51.2</td>
+  <td>51.0</td>
+  <td>+0.2</td>
+  <td>50.7</td>
+  <td>50.4</td>
+  <td>+0.3</td>
+</tr>
+<tr>
+  <td>Qwen2-1.5B-instruct</td>
+  <td>52.4</td>
+  <td>47.1</td>
+  <td>47.5</td>
+  <td>-0.4</td>
+  <td>45.2</td>
+  <td>44.5</td>
+  <td>+0.7</td>
+</tr>
+<tr>
+  <td>Gemma-2-2B</td>
+  <td>51.3</td>
+  <td>43.9</td>
+  <td>42.4</td>
+  <td>+1.5</td>
+  <td>30.5</td>
+  <td>29.4</td>
+  <td>+0.9</td>
+</tr>
+<tr>
+  <td>Qwen2.5-0.5B-instruct</td>
+  <td>24.1</td>
+  <td>41.9</td>
+  <td>41.1</td>
+  <td>+0.8</td>
+  <td>36.0</td>
+  <td>34.9</td>
+  <td>+1.1</td>
+</tr>
+<tr>
+  <td>Internlm-2-chat-1.8b</td>
+  <td>47.1</td>
+  <td>40.5</td>
+  <td>39.4</td>
+  <td>+1.1</td>
+  <td>41.2</td>
+  <td>39.8</td>
+  <td>+1.4</td>
+</tr>
+<tr>
+  <td>Qwen2-0.5B-instruct</td>
+  <td>37.9</td>
+  <td>38.3</td>
+  <td>38.3</td>
+  <td>+0.0</td>
+  <td>33.5</td>
+  <td>33.5</td>
+  <td>+0.0</td>
+</tr>
+  </tbody>
+</table>
+
+## 5. Data Construction Pipeline
+![Fig3](./Figures/Fig_3.png)
+The pipeline involves (1) MCQ Collection to gather a diverse set of questions; (2) MCQ Cleaning to ensure quality; (3) Difficulty Sampling to ensure an appropriate difficulty distribution for questions; (4) LLMs checking: The LLMs, including GPT-4o, Gemini, and Claude, are reviewing the accuracy and safety of the data; and (5) Contamination-Free Processing to prevent data leakage and maintain dataset purity. Ultimately, this process results in the MMLU-CF, consisting of 10,000 questions for the closed-source test set and 10,000 for the open-source validation set.
+
+## 6. Contact
+For any inquiries or concerns, feel free to reach out to us via Email: [Qihao Zhao](qhzhaoo@gmail.com) and [Yangyu Huang](yanghuan@microsoft.com).
+
+## 7. Citation
+```
+@misc{zhao2024mmlucfcontaminationfreemultitasklanguage,
+      title={MMLU-CF: A Contamination-free Multi-task Language Understanding Benchmark}, 
+      author={Qihao Zhao and Yangyu Huang and Tengchao Lv and Lei Cui and Qinzheng Sun and Shaoguang Mao and Xin Zhang and Ying Xin and Qiufeng Yin and Scarlett Li and Furu Wei},
+      year={2024},
+      eprint={2412.15194},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2412.15194}, 
+}
+```
+
+## 8. License
+This repository is licensed under the [MIT](https://github.com/microsoft/PEACE/blob/main/LICENSE) License.
+The validation dataset of MMLU-CF is subject to the [CDLA-2.0](https://cdla.dev/permissive-2-0/) License.

--- a/configs/datasets/mmlu_cf/mmlu_cf_categories.py
+++ b/configs/datasets/mmlu_cf/mmlu_cf_categories.py
@@ -1,0 +1,16 @@
+categories = [
+    'Math',
+    'Physics',
+    'Chemistry',
+    'Law',
+    'Engineering',
+    'Other',
+    'Economics',
+    'Health',
+    'Psychology',
+    'Business',
+    'Biology',
+    'Philosophy',
+    'Computer_Science',
+    'History',
+]

--- a/configs/datasets/mmlu_cf/mmlu_cf_few_shot.py
+++ b/configs/datasets/mmlu_cf/mmlu_cf_few_shot.py
@@ -1,0 +1,64 @@
+from mmengine.config import read_base
+from opencompass.openicl.icl_prompt_template import PromptTemplate
+from opencompass.openicl.icl_retriever import FixKRetriever
+from opencompass.openicl.icl_inferencer import GenInferencer
+from opencompass.openicl.icl_evaluator import AccwithDetailsEvaluator
+from opencompass.datasets import MMLUCFDataset
+from opencompass.utils.text_postprocessors import first_option_postprocess
+
+with read_base():
+    from .mmlu_cf_categories import categories
+
+mmlu_cf_reader_cfg = dict(
+    input_columns=['input', 'A', 'B', 'C', 'D'],
+    output_column='target',
+    train_split='dev')
+
+mmlu_cf_datasets = []
+for _name in categories:
+    _hint = f'There is a single choice question. Answer the question by replying A, B, C or D.'
+    mmlu_cf_infer_cfg = dict(
+        ice_template=dict(
+            type=PromptTemplate,
+            template=dict(round=[
+                dict(
+                    role='HUMAN',
+                    prompt=
+                    f'{_hint}\nQuestion: {{input}}\nA. {{A}}\nB. {{B}}\nC. {{C}}\nD. {{D}}\nAnswer: '
+                ),
+                dict(role='BOT', prompt='{target}\n')
+            ]),
+        ),
+        prompt_template=dict(
+            type=PromptTemplate,
+            template=dict(
+                begin='</E>',
+                round=[
+                    dict(
+                        role='HUMAN',
+                        prompt=f'{_hint}\nQuestion: {{input}}\nA. {{A}}\nB. {{B}}\nC. {{C}}\nD. {{D}}\nAnswer: '
+                    ),
+                ],
+            ),
+            ice_token='</E>',
+        ),
+        retriever=dict(type=FixKRetriever, fix_id_list=[0, 1, 2, 3, 4]),
+        inferencer=dict(type=GenInferencer),
+    )
+
+    mmlu_cf_eval_cfg = dict(
+        evaluator=dict(type=AccwithDetailsEvaluator),
+        pred_postprocessor=dict(type=first_option_postprocess, options='ABCD'))
+
+    mmlu_cf_datasets.append(
+        dict(
+            abbr=f'mmlu_cf_{_name}',
+            type=MMLUCFDataset,
+            path='opencompass/mmlu_cf',
+            name=_name,
+            reader_cfg=mmlu_cf_reader_cfg,
+            infer_cfg=mmlu_cf_infer_cfg,
+            eval_cfg=mmlu_cf_eval_cfg,
+        ))
+
+del _name, _hint

--- a/configs/datasets/mmlu_cf/mmlu_cf_gen.py
+++ b/configs/datasets/mmlu_cf/mmlu_cf_gen.py
@@ -1,0 +1,64 @@
+from mmengine.config import read_base
+from opencompass.openicl.icl_prompt_template import PromptTemplate
+from opencompass.openicl.icl_retriever import FixKRetriever
+from opencompass.openicl.icl_inferencer import GenInferencer
+from opencompass.openicl.icl_evaluator import AccwithDetailsEvaluator
+from opencompass.datasets import MMLUCFDataset
+from opencompass.utils.text_postprocessors import first_option_postprocess
+
+with read_base():
+    from .mmlu_cf_categories import categories
+
+mmlu_cf_reader_cfg = dict(
+    input_columns=['input', 'A', 'B', 'C', 'D'],
+    output_column='target',
+    train_split='dev')
+
+mmlu_cf_datasets = []
+for _name in categories:
+    _hint = f'There is a single choice question. Answer the question by replying A, B, C or D.'
+    mmlu_cf_infer_cfg = dict(
+        ice_template=dict(
+            type=PromptTemplate,
+            template=dict(round=[
+                dict(
+                    role='HUMAN',
+                    prompt=
+                    f'{_hint}\nQuestion: {{input}}\nA. {{A}}\nB. {{B}}\nC. {{C}}\nD. {{D}}\nAnswer: '
+                ),
+                dict(role='BOT', prompt='{target}\n')
+            ]),
+        ),
+        prompt_template=dict(
+            type=PromptTemplate,
+            template=dict(
+                begin='</E>',
+                round=[
+                    dict(
+                        role='HUMAN',
+                        prompt=f'{_hint}\nQuestion: {{input}}\nA. {{A}}\nB. {{B}}\nC. {{C}}\nD. {{D}}\nAnswer: '
+                    ),
+                ],
+            ),
+            ice_token='</E>',
+        ),
+        retriever=dict(type=FixKRetriever, fix_id_list=[0, 1, 2, 3, 4]),
+        inferencer=dict(type=GenInferencer),
+    )
+
+    mmlu_cf_eval_cfg = dict(
+        evaluator=dict(type=AccwithDetailsEvaluator),
+        pred_postprocessor=dict(type=first_option_postprocess, options='ABCD'))
+
+    mmlu_cf_datasets.append(
+        dict(
+            abbr=f'mmlu_cf_{_name}',
+            type=MMLUCFDataset,
+            path='opencompass/mmlu_cf/',
+            name=_name,
+            reader_cfg=mmlu_cf_reader_cfg,
+            infer_cfg=mmlu_cf_infer_cfg,
+            eval_cfg=mmlu_cf_eval_cfg,
+        ))
+
+del _name, _hint

--- a/configs/datasets/mmlu_cf/mmlu_cf_zero_shot.py
+++ b/configs/datasets/mmlu_cf/mmlu_cf_zero_shot.py
@@ -1,0 +1,64 @@
+from mmengine.config import read_base
+from opencompass.openicl.icl_prompt_template import PromptTemplate
+from opencompass.openicl.icl_retriever import ZeroRetriever
+from opencompass.openicl.icl_inferencer import GenInferencer
+from opencompass.openicl.icl_evaluator import AccwithDetailsEvaluator
+from opencompass.datasets import MMLUCFDataset
+from opencompass.utils.text_postprocessors import first_option_postprocess
+
+with read_base():
+    from .mmlu_cf_categories import categories
+
+mmlu_cf_reader_cfg = dict(
+    input_columns=['input', 'A', 'B', 'C', 'D'],
+    output_column='target',
+    train_split='dev')
+
+mmlu_cf_datasets = []
+for _name in categories:
+    _hint = f'There is a single choice question. Answer the question by replying A, B, C or D.'
+    mmlu_cf_infer_cfg = dict(
+        ice_template=dict(
+            type=PromptTemplate,
+            template=dict(round=[
+                dict(
+                    role='HUMAN',
+                    prompt=
+                    f'{_hint}\nQuestion: {{input}}\nA. {{A}}\nB. {{B}}\nC. {{C}}\nD. {{D}}\nAnswer: '
+                ),
+                dict(role='BOT', prompt='{target}\n')
+            ]),
+        ),
+        prompt_template=dict(
+            type=PromptTemplate,
+            template=dict(
+                begin='</E>',
+                round=[
+                    dict(
+                        role='HUMAN',
+                        prompt=f'{_hint}\nQuestion: {{input}}\nA. {{A}}\nB. {{B}}\nC. {{C}}\nD. {{D}}\nAnswer: '
+                    ),
+                ],
+            ),
+            ice_token='</E>',
+        ),
+        retriever=dict(type= ZeroRetriever),
+        inferencer=dict(type=GenInferencer),
+    )
+
+    mmlu_cf_eval_cfg = dict(
+        evaluator=dict(type=AccwithDetailsEvaluator),
+        pred_postprocessor=dict(type=first_option_postprocess, options='ABCD'))
+
+    mmlu_cf_datasets.append(
+        dict(
+            abbr=f'mmlu_cf_{_name}',
+            type=MMLUCFDataset,
+            path='opencompass/mmlu_cf',
+            name=_name,
+            reader_cfg=mmlu_cf_reader_cfg,
+            infer_cfg=mmlu_cf_infer_cfg,
+            eval_cfg=mmlu_cf_eval_cfg,
+        ))
+
+del _name, _hint

--- a/configs/eval_corebench_2409_base_objective.py
+++ b/configs/eval_corebench_2409_base_objective.py
@@ -13,6 +13,7 @@ with read_base():
     ## Core Set
     # ## Examination
     from opencompass.configs.datasets.mmlu.mmlu_ppl_ac766d import mmlu_datasets
+    from opencompass.configs.datasets.mmlu_cf.mmlu_cf_gen import mmlu_cf_datasets
     from opencompass.configs.datasets.mmlu_pro.mmlu_pro_few_shot_gen_bfaf90 import \
         mmlu_pro_datasets
     from opencompass.configs.datasets.cmmlu.cmmlu_ppl_041cbf import \
@@ -42,6 +43,7 @@ with read_base():
 
     # Summarizer
     from opencompass.configs.summarizers.groups.mmlu import mmlu_summary_groups
+    from opencompass.configs.summarizers.groups.mmlu_cf import mmlu_cf_summary_groups
     from opencompass.configs.summarizers.groups.mmlu_pro import mmlu_pro_summary_groups
     from opencompass.configs.summarizers.groups.cmmlu import cmmlu_summary_groups
     from opencompass.configs.summarizers.groups.bbh import bbh_summary_groups
@@ -75,6 +77,7 @@ core_summary_groups = [
         'subsets': [
             ['mmlu', 'accuracy'],
             ['mmlu_pro', 'accuracy'],
+            ['mmlu_cf', 'accuracy'],
             ['cmmlu', 'accuracy'],
             ['bbh', 'naive_average'],
             ['hellaswag', 'accuracy'],
@@ -95,6 +98,7 @@ summarizer = dict(
     dataset_abbrs=[
         ['mmlu', 'accuracy'],
         ['mmlu_pro', 'accuracy'],
+        ['mmlu_cf', 'accuracy'],
         ['cmmlu', 'accuracy'],
         ['bbh', 'naive_average'],
         ['hellaswag', 'accuracy'],
@@ -131,6 +135,22 @@ summarizer = dict(
         ['mmlu_pro_philosophy', 'accuracy'],
         ['mmlu_pro_computer_science','accuracy'],
         ['mmlu_pro_history', 'accuracy'],
+        '',
+        ['mmlu_cf', 'accuracy'],
+        ['mmlu_cf_math','accuracy'],
+        ['mmlu_cf_physics', 'accuracy'],
+        ['mmlu_cf_chemistry', 'accuracy'],
+        ['mmlu_cf_law', 'accuracy'],
+        ['mmlu_cf_engineering', 'accuracy'],
+        ['mmlu_cf_other', 'accuracy'],
+        ['mmlu_cf_economics', 'accuracy'],
+        ['mmlu_cf_health', 'accuracy'],
+        ['mmlu_cf_psychology', 'accuracy'],
+        ['mmlu_cf_business', 'accuracy'],
+        ['mmlu_cf_biology', 'accuracy'],
+        ['mmlu_cf_philosophy', 'accuracy'],
+        ['mmlu_cf_computer_science','accuracy'],
+        ['mmlu_cf_history', 'accuracy'],
         '',
         ['cmmlu', 'accuracy'],
         ['cmmlu-stem', 'accuracy'],

--- a/configs/eval_mmlu_cf.py
+++ b/configs/eval_mmlu_cf.py
@@ -1,0 +1,34 @@
+from mmengine.config import read_base
+
+with read_base():
+    from opencompass.configs.datasets.mmlu_cf.mmlu_cf_gen import mmlu_cf_datasets
+
+    from opencompass.configs.models.qwen.lmdeploy_qwen2_7b_instruct import models as lmdeploy_qwen2_7b_instruct_model
+    from opencompass.configs.models.hf_llama.lmdeploy_llama3_8b_instruct import models as lmdeploy_llama3_8b_instruct_model
+
+    from opencompass.configs.summarizers.mmlu_cf import summarizer
+    from opencompass.configs.internal.clusters.local import infer_num_worker as infer
+    from opencompass.configs.internal.clusters.local import eval
+
+datasets = sum([v for k, v in locals().items() if k.endswith('_datasets') or k == 'datasets'], [])
+models = sum([v for k, v in locals().items() if k.endswith('_model')], [])
+
+work_dir = 'outputs/debug/mmlu_cf'
+
+# dataset                    version    metric         mode      qwen2-7b-instruct-turbomind    llama-3-8b-instruct-turbomind
+# -------------------------  ---------  -------------  ------  -----------------------------  -------------------------------
+# mmlu_cf                   -          naive_average  gen                             46.18                            43.92
+# mmlu_cf_biology           736233     accuracy       gen                             63.74                            64.02
+# mmlu_cf_business          736233     accuracy       gen                             53.23                            46.01
+# mmlu_cf_chemistry         736233     accuracy       gen                             35.25                            32.42
+# mmlu_cf_computer_science  736233     accuracy       gen                             47.07                            44.88
+# mmlu_cf_economics         736233     accuracy       gen                             59.00                            53.79
+# mmlu_cf_engineering       736233     accuracy       gen                             26.73                            33.54
+# mmlu_cf_health            736233     accuracy       gen                             47.31                            51.34
+# mmlu_cf_history           736233     accuracy       gen                             42.78                            42.26
+# mmlu_cf_law               736233     accuracy       gen                             28.07                            26.98
+# mmlu_cf_math              736233     accuracy       gen                             53.59                            37.53
+# mmlu_cf_philosophy        736233     accuracy       gen                             42.28                            42.48
+# mmlu_cf_physics           736233     accuracy       gen                             39.11                            33.64
+# mmlu_cf_psychology        736233     accuracy       gen                             60.90                            59.65
+# mmlu_cf_other             736233     accuracy       gen                             47.40                            46.32

--- a/configs/summarizers/chat_OC15.py
+++ b/configs/summarizers/chat_OC15.py
@@ -2,6 +2,7 @@ from mmengine.config import read_base
 
 with read_base():
     from .groups.mmlu import mmlu_summary_groups
+    from .groups.mmlu_cf import mmlu_cf_summary_groups
     from .groups.cmmlu import cmmlu_summary_groups
     from .groups.ceval import ceval_summary_groups
     from .groups.bbh import bbh_summary_groups
@@ -13,6 +14,7 @@ other_summary_groups = [
         'name': 'average',
         'subsets': [
             ['mmlu', 'naive_average'],
+            ['mmlu_cf', 'naive_average'],
             ['cmmlu', 'naive_average'],
             ['ceval', 'naive_average'],
             ['GaokaoBench', 'weighted_average'],
@@ -37,6 +39,7 @@ summarizer = dict(
     dataset_abbrs=[
         ['average', 'naive_average'],
         ['mmlu', 'naive_average'],
+        ['mmlu_cf', 'naive_average'],
         ['cmmlu', 'naive_average'],
         ['ceval', 'naive_average'],
         ['GaokaoBench', 'weighted_average'],

--- a/configs/summarizers/chat_OC15_multi_faceted.py
+++ b/configs/summarizers/chat_OC15_multi_faceted.py
@@ -3,6 +3,7 @@ from opencompass.summarizers import MultiFacetedSummarizer
 
 with read_base():
     from .groups.mmlu import mmlu_summary_groups
+    from .groups.mmlu_cf import mmlu_cf_summary_groups
     from .groups.cmmlu import cmmlu_summary_groups
     from .groups.ceval import ceval_summary_groups
     from .groups.bbh import bbh_summary_groups
@@ -13,6 +14,7 @@ other_summary_groups = [
         'name': 'average',
         'subsets': [
             ['mmlu', 'naive_average'],
+            ['mmlu_cf', 'naive_average'],
             ['cmmlu', 'naive_average'],
             ['ceval', 'naive_average'],
             ['GaokaoBench', 'weighted_average'],
@@ -36,6 +38,7 @@ other_summary_groups = [
 overall_dataset_abbrs = [
     ['average', 'naive_average'],
     ['mmlu', 'naive_average'],
+    ['mmlu_cf', 'naive_average'],
     ['cmmlu', 'naive_average'],
     ['ceval', 'naive_average'],
     ['GaokaoBench', 'weighted_average'],
@@ -53,6 +56,12 @@ overall_dataset_abbrs = [
     ['GPQA_diamond', 'accuracy'],
     ['IFEval', 'Prompt-level-strict-accuracy'],
 ]
+
+mmlu_cf_summary_groups_dict = {g['name']: g['subsets'] for g in mmlu_cf_summary_groups}
+mmlu_cf_dataset_abbrs = [
+    ['mmlu_cf', 'naive_average'],
+]
+
 
 mmlu_summary_groups_dict = {g['name']: g['subsets'] for g in mmlu_summary_groups}
 mmlu_dataset_abbrs = [

--- a/configs/summarizers/example.py
+++ b/configs/summarizers/example.py
@@ -3,6 +3,7 @@ from mmengine.config import read_base
 with read_base():
     from .groups.agieval import agieval_summary_groups
     from .groups.mmlu import mmlu_summary_groups
+    from .groups.mmlu_cf import mmlu_cf_summary_groups
     from .groups.cmmlu import cmmlu_summary_groups
     from .groups.ceval import ceval_summary_groups
     from .groups.bbh import bbh_summary_groups

--- a/configs/summarizers/groups/mmlu_cf.py
+++ b/configs/summarizers/groups/mmlu_cf.py
@@ -1,0 +1,5 @@
+categories = ['Computer Science', 'Math', 'Physics', 'Chemistry', 'Law', 'Engineering', 'Other', 'Economics', 'Health', 'Psychology', 'Business', 'Biology', 'Philosophy',  'History']
+
+mmlu_cf_summary_groups = [
+    {'name': 'mmlu_cf', 'subsets': ['mmlu_cf_' + c.replace(' ', '_') for c in categories]},
+]

--- a/configs/summarizers/mmlu_cf.py
+++ b/configs/summarizers/mmlu_cf.py
@@ -1,0 +1,25 @@
+from mmengine.config import read_base
+
+with read_base():
+    from .groups.mmlu_cf import mmlu_cf_summary_groups
+
+summarizer = dict(
+    dataset_abbrs=[
+        'mmlu_cf',
+        'mmlu_cf_Biology',
+        'mmlu_cf_Business',
+        'mmlu_cf_Chemistry',
+        'mmlu_cf_Computer_Science',
+        'mmlu_cf_Economics',
+        'mmlu_cf_Engineering',
+        'mmlu_cf_Health',
+        'mmlu_cf_History',
+        'mmlu_cf_Law',
+        'mmlu_cf_Math',
+        'mmlu_cf_Philosophy',
+        'mmlu_cf_Physics',
+        'mmlu_cf_Psychology',
+        'mmlu_cf_Other',
+    ],
+    summary_groups=sum([v for k, v in locals().items() if k.endswith('_summary_groups')], []),
+)

--- a/opencompass/configs/dataset_collections/chat_OC15.py
+++ b/opencompass/configs/dataset_collections/chat_OC15.py
@@ -2,6 +2,7 @@ from mmengine.config import read_base
 
 with read_base():
     from opencompass.configs.datasets.mmlu.mmlu_gen_4d595a import mmlu_datasets
+    from opencompass.configs.datasets.mmlu_cf.mmlu_cf_gen import mmlu_cf_datasets
     from opencompass.configs.datasets.cmmlu.cmmlu_gen_c13365 import cmmlu_datasets
     from opencompass.configs.datasets.ceval.ceval_gen_5f30c7 import ceval_datasets
     from opencompass.configs.datasets.GaokaoBench.GaokaoBench_no_subjective_gen_4c31db import GaokaoBench_datasets

--- a/opencompass/configs/datasets/mmlu_cf/README.md
+++ b/opencompass/configs/datasets/mmlu_cf/README.md
@@ -1,0 +1,614 @@
+# MMLU-CF: A Contamination-free Multi-task Language Understanding Benchmark
+
+<div align="center">
+
+![](https://img.shields.io/badge/Task-MMLU_CF-orange)
+![](https://img.shields.io/badge/Data-Released-green)
+![](https://img.shields.io/badge/Code_License-MIT-blue)
+
+</div>
+
+<p align="center">
+  <a href="https://arxiv.org/pdf/2412.15194"><b>[📜 Paper]</b></a> •
+  <a href="https://huggingface.co/datasets/microsoft/MMLU-CF"><b>[🤗 HF Dataset]</b></a> •
+  <a href="https://github.com/microsoft/MMLU-CF"><b>[🐱 GitHub]</b></a>
+</p>
+
+## 📢 News and Updates
+[2024.12.01] 🔥We have initialized the repository.  
+[2024.12.16] 🔥We have added the evaluation results of Phi-4-14B and Llama-3.3-70B-Instruct.  
+[2024.12.20] 🔥We have released the validation dataset of MMLU-CF.  
+
+
+## 1. The Motivation of MMLU-CF
+
+<!-- MMLU-CF is a contamination-free and more challenging multiple-choice question benchmark. This dataset contains 10K questions each for the validation set and test set, covering various disciplines. -->
+
+- The open-source nature of these benchmarks and the broad sources of training data for LLMs have inevitably led to benchmark contamination, resulting in unreliable evaluation results. To alleviate this issue, we propose MMLU-CF.
+- (a) An instance of leakage in MMLU. When questions are used as prompt from the MMLU, certain LLMs, due to their memorization capabilities, directly provide **choices identical to the original ones**. (b) When questions are used as prompt from the MMLU-CF, LLMs only provide guessed choices.
+This indicates that the MMLU test set suffers from data contamination and memorization by some LLMs, while the proposed MMLU-CF avoids such leakage.
+<p float="center">
+  <img src="./Figures/Fig_1_a.png" alt="Fig1_a" width="45%" />
+  <img src="./Figures/Fig_1_b.png" alt="Fig1_b" width="45%" />
+</p>
+
+
+## 2. How to Evaluate Your Models on the MMLU-CF Validation/Test Set
+
+  #### (1) We perform automated testing only on Huggingface models. After following the steps outlined below and obtaining the validation set results from [OpenCompass](https://github.com/open-compass/opencompass), the test set results can then be accessed via GitHub Issues. 
+  
+  **Step 1**. **Validation set evaluation**: Obtaining the validation results for your model using LLM evaluation tools, [OpenCompass](https://github.com/open-compass/opencompass). The validation dataset download from [🤗 Huggingface](https://huggingface.co/datasets/microsoft/MMLU-CF). The data directory structure in the opencompass:
+
+```
+data
+└── mmlu_cf 
+    ├── dev
+    └── val
+```
+  
+  **Step 2**. **Test set evaluation**: With the validation results, submit a GitHub issue on the [MMLU-CF](https://github.com/) GitHub homepage to request the test set results. Please follow the format below:
+
+Example 1,
+```
+Title: 
+Test set evaluation Request - add HF model [microsoft/phi-4]  
+Content: 
+The result on validation set: 68.5%
+```
+Example 2,
+<p>
+  <img src="./Figures/Fig_6.png" alt="Fig6" width="80%" style="display: block; margin: 0 auto;" />
+</p>
+
+  **Notably**:
+   - Ensure you use the format with square brackets `[ ]` as shown. The model name **microsoft/phi-4** corresponds to the name on HuggingFace.
+   - We will automatically submit your model. The time to receive the results depends on the number of models being evaluated, but it typically takes **1-2 weeks**.
+
+  #### (2) For API models, if OpenCompass updates the model interface, you can obtain the test set results by sending a temporary key to [Email](yangyu.huang@microsoft.com) after receiving the validation set results.
+
+
+## 3. What is the Difference between MMLU-CF and MMLU
+MMLU focuses on the breadth and reasoning without considering contamination prevention. We apply three decontamination rules to mitigate unintentional data leakage while collecting data from a broader domain. Meanwhile, our MMLU-CF benchmark maintains the test set closed-source to prevent malicious data leakage.
+
+<p float="left">
+  <img src="./Figures/Fig_4.png" alt="Fig4" width="55%" />
+  <span style="display:inline-block; width: 10%;"></span>
+  <img src="./Figures/Fig_5.png" alt="Fig5" width="30%" />
+</p>
+
+
+## 4. Leaderboard
+<table>
+  <thead>
+    <tr>
+      <th rowspan="2">Model</th>
+      <th colspan="1">MMLU </th>
+      <th colspan="6">MMLU-CF </th>
+    </tr>
+    <tr>
+      <th>5-shot   </th>
+      <th>5-shot Test   </th>
+      <th>5-shot Validation  </th>
+      <th>5-shot Δ   </th>
+      <th>0-shot Test   </th>
+      <th>0-shot Validation    </th>
+      <th>0-shot Δ    </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>API</strong></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>GPT-4o</td>
+      <td>88.0</td>
+      <td>73.4</td>
+      <td>73.4</td>
+      <td>+0.0</td>
+      <td>71.9</td>
+      <td>72.4</td>
+      <td>-0.5</td>
+    </tr>
+    <tr>
+      <td>GPT-4-Turbo</td>
+      <td>86.5</td>
+      <td>70.4</td>
+      <td>70.1</td>
+      <td>+0.3</td>
+      <td>68.9</td>
+      <td>68.7</td>
+      <td>+0.1</td>
+    </tr>
+    <tr>
+      <td>GPT-4o-mini</td>
+      <td>81.8</td>
+      <td>65.5</td>
+      <td>65.1</td>
+      <td>+0.4</td>
+      <td>66.0</td>
+      <td>65.3</td>
+      <td>+0.7</td>
+    </tr>
+    <tr>
+      <td>Gemini-1.5-Flash</td>
+      <td>78.7</td>
+      <td>64.8</td>
+      <td>64.9</td>
+      <td>-0.1</td>
+      <td>56.7</td>
+      <td>56.9</td>
+      <td>-0.2</td>
+    </tr>
+    <tr>
+      <td>GPT-3.5-Turbo</td>
+      <td>71.4</td>
+      <td>58.2</td>
+      <td>59.0</td>
+      <td>-0.8</td>
+      <td>57.2</td>
+      <td>58.1</td>
+      <td>-0.9</td>
+    </tr>
+    <tr>
+      <td><strong>Large</strong></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Qwen2.5-72B-instruct</td>
+      <td>85.3</td>
+      <td>71.6</td>
+      <td>71.3</td>
+      <td>+0.3</td>
+      <td>70.6</td>
+      <td>70.4</td>
+      <td>+0.2</td>
+    </tr>
+    <tr>
+      <td>Llama-3-70B-instruct</td>
+      <td>82.0</td>
+      <td>68.9</td>
+      <td>68.8</td>
+      <td>+0.1</td>
+      <td>68.1</td>
+      <td>67.4</td>
+      <td>+0.7</td>
+    </tr>
+    <tr>
+      <td>Llama-3.3-70B-instruct</td>
+      <td>86.3</td>
+      <td>68.8</td>
+      <td>67.8</td>
+      <td>+1.0</td>
+      <td>67.6</td>
+      <td>67.5</td>
+      <td>+0.1</td>
+    </tr>
+    <tr>
+      <td>Llama-3.1-70B-instruct</td>
+      <td>86.0</td>
+      <td>68.7</td>
+      <td>68.1</td>
+      <td>+0.6</td>
+      <td>70.4</td>
+      <td>69.7</td>
+      <td>+0.7</td>
+    </tr>
+    <tr>
+      <td>Phi-3.5-MoE-instruct</td>
+      <td>78.9</td>
+      <td>64.6</td>
+      <td>64.5</td>
+      <td>+0.1</td>
+      <td>63.1</td>
+      <td>62.1</td>
+      <td>+1.0</td>
+    </tr>
+    <tr>
+      <td>Qwen2-72B-instruct</td>
+      <td>82.3</td>
+      <td>63.7</td>
+      <td>64.3</td>
+      <td>-0.6</td>
+      <td>62.4</td>
+      <td>62.5</td>
+      <td>-0.1</td>
+    </tr>
+    <tr>
+      <td>Mixtral-8x22B-instruct</td>
+      <td>76.2</td>
+      <td>62.8</td>
+      <td>62.5</td>
+      <td>+0.3</td>
+      <td>65.3</td>
+      <td>64.8</td>
+      <td>+0.5</td>
+    </tr>
+    <tr>
+  <td>Qwen1.5-72B-chat</td>
+  <td>75.6</td>
+  <td>59.8</td>
+  <td>60.2</td>
+  <td>-0.4</td>
+  <td>59.1</td>
+  <td>59.6</td>
+  <td>-0.5</td>
+</tr>
+<tr>
+  <td>Llama-2-70B-chat</td>
+  <td>68.9</td>
+  <td>52.2</td>
+  <td>51.8</td>
+  <td>+0.4</td>
+  <td>51.2</td>
+  <td>50.9</td>
+  <td>+0.3</td>
+</tr>
+<tr>
+  <td><strong>Medium</strong></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+</tr>
+<tr>
+  <td>Qwen2.5-32B-instruct</td>
+  <td>83.9</td>
+  <td>69.7</td>
+  <td>68.8</td>
+  <td>+0.9</td>
+  <td>68.9</td>
+  <td>68.8</td>
+  <td>+0.1</td>
+</tr>
+<tr>
+  <td>Phi-4-14B</td>
+  <td>84.8</td>
+  <td>67.8</td>
+  <td>68.5</td>
+  <td>-0.7</td>
+  <td>68.5</td>
+  <td>69.4</td>
+  <td>-0.9</td>
+</tr>
+<tr>
+  <td>Qwen2.5-14B-instruct</td>
+  <td>79.9</td>
+  <td>66.4</td>
+  <td>66.1</td>
+  <td>+0.3</td>
+  <td>67.0</td>
+  <td>66.0</td>
+  <td>+1.0</td>
+</tr>
+<tr>
+  <td>Phi-3-medium-instruct</td>
+  <td>77.9</td>
+  <td>64.2</td>
+  <td>64.2</td>
+  <td>+0.0</td>
+  <td>62.5</td>
+  <td>62.7</td>
+  <td>-0.2</td>
+</tr>
+<tr>
+  <td>Gemma2-27B</td>
+  <td>75.2</td>
+  <td>63.9</td>
+  <td>63.5</td>
+  <td>+0.4</td>
+  <td>64.2</td>
+  <td>64.0</td>
+  <td>+0.2</td>
+</tr>
+<tr>
+  <td>Yi-1.5-34B-chat</td>
+  <td>76.8</td>
+  <td>61.3</td>
+  <td>60.5</td>
+  <td>+0.8</td>
+  <td>60.6</td>
+  <td>59.5</td>
+  <td>+1.1</td>
+</tr>
+<tr>
+  <td>Mixtral-8x7B-instruct-v0.1</td>
+  <td>70.5</td>
+  <td>58.3</td>
+  <td>57.1</td>
+  <td>-1.2</td>
+  <td>58.9</td>
+  <td>58.5</td>
+  <td>+0.4</td>
+</tr>
+<tr>
+  <td>Deepseek-v2-lite-chat</td>
+  <td>55.7</td>
+  <td>49.3</td>
+  <td>48.7</td>
+  <td>+0.6</td>
+  <td>48.2</td>
+  <td>47.7</td>
+  <td>+0.5</td>
+</tr>
+<tr>
+  <td>Baichuan-2-13B-chat</td>
+  <td>57.3</td>
+  <td>48.3</td>
+  <td>48.6</td>
+  <td>-0.3</td>
+  <td>47.1</td>
+  <td>48.1</td>
+  <td>-1.0</td>
+</tr>
+<tr>
+  <td>Llama-2-13B-chat</td>
+  <td>54.8</td>
+  <td>42.8</td>
+  <td>42.1</td>
+  <td>+0.7</td>
+  <td>44.8</td>
+  <td>44.6</td>
+  <td>+0.2</td>
+</tr>
+<tr>
+  <td><strong>Small</strong></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+</tr>
+<tr>
+  <td>Qwen2.5-7B-instruct</td>
+  <td>75.4</td>
+  <td>61.3</td>
+  <td>60.4</td>
+  <td>+0.9</td>
+  <td>59.3</td>
+  <td>58.6</td>
+  <td>+0.7</td>
+</tr>
+<tr>
+  <td>Qwen2-7B-instruct</td>
+  <td>70.5</td>
+  <td>58.1</td>
+  <td>57.9</td>
+  <td>+0.2</td>
+  <td>58.3</td>
+  <td>57.4</td>
+  <td>+0.9</td>
+</tr>
+<tr>
+  <td>Glm-4-9B-chat</td>
+  <td>72.4</td>
+  <td>57.8</td>
+  <td>57.9</td>
+  <td>-0.1</td>
+  <td>58.6</td>
+  <td>58.7</td>
+  <td>-0.1</td>
+</tr>
+<tr>
+  <td>Internlm-2.5-7B-chat</td>
+  <td>72.8</td>
+  <td>57.3</td>
+  <td>56.8</td>
+  <td>+0.5</td>
+  <td>57.9</td>
+  <td>56.9</td>
+  <td>+1.0</td>
+</tr>
+<tr>
+  <td>Llama-3-8B-instruct</td>
+  <td>68.4</td>
+  <td>57.3</td>
+  <td>56.5</td>
+  <td>+0.8</td>
+  <td>56.4</td>
+  <td>55.4</td>
+  <td>+1.0</td>
+</tr>
+<tr>
+  <td>Llama-3.1-8B-instruct</td>
+  <td>68.1</td>
+  <td>57.1</td>
+  <td>57.9</td>
+  <td>-0.8</td>
+  <td>56.1</td>
+  <td>56.1</td>
+  <td>+0.0</td>
+</tr>
+<tr>
+  <td>Gemma-2-9B</td>
+  <td>71.3</td>
+  <td>53.7</td>
+  <td>53.3</td>
+  <td>+0.4</td>
+  <td>32.1</td>
+  <td>31.2</td>
+  <td>+0.9</td>
+</tr>
+<tr>
+  <td>Yi-1.5-6B-chat</td>
+  <td>62.8</td>
+  <td>52.8</td>
+  <td>51.4</td>
+  <td>+1.4</td>
+  <td>52.2</td>
+  <td>51.9</td>
+  <td>+0.3</td>
+</tr>
+<tr>
+  <td>Mistral-7B-instruct-v0.3</td>
+  <td>60.3</td>
+  <td>50.7</td>
+  <td>50.9</td>
+  <td>-0.2</td>
+  <td>51.1</td>
+  <td>50.9</td>
+  <td>+0.2</td>
+</tr>
+<tr>
+  <td>Baichuan-2-7B-chat</td>
+  <td>52.9</td>
+  <td>44.5</td>
+  <td>43.9</td>
+  <td>+0.6</td>
+  <td>43.9</td>
+  <td>44.0</td>
+  <td>-0.1</td>
+</tr>
+<tr>
+  <td>Llama-2-7B-chat</td>
+  <td>45.3</td>
+  <td>39.4</td>
+  <td>38.5</td>
+  <td>+0.9</td>
+  <td>41.9</td>
+  <td>40.9</td>
+  <td>+1.0</td>
+</tr>
+<tr>
+  <td><strong>Mini</strong></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+</tr>
+<tr>
+  <td>Phi-3-mini-instruct (3.8B)</td>
+  <td>70.9</td>
+  <td>57.9</td>
+  <td>58.1</td>
+  <td>-0.2</td>
+  <td>58.2</td>
+  <td>57.5</td>
+  <td>+0.7</td>
+</tr>
+<tr>
+  <td>Phi-3.5-mini-instruct (3.8B)</td>
+  <td>69.1</td>
+  <td>57.9</td>
+  <td>57.4</td>
+  <td>+0.5</td>
+  <td>58.3</td>
+  <td>57.7</td>
+  <td>+0.6</td>
+</tr>
+<tr>
+  <td>Qwen2.5-3B-instruct</td>
+  <td>64.4</td>
+  <td>55.9</td>
+  <td>56.4</td>
+  <td>-0.5</td>
+  <td>54.3</td>
+  <td>53.9</td>
+  <td>+0.4</td>
+</tr>
+<tr>
+  <td>Qwen2.5-1.5B-instruct</td>
+  <td>50.7</td>
+  <td>51.2</td>
+  <td>51.0</td>
+  <td>+0.2</td>
+  <td>50.7</td>
+  <td>50.4</td>
+  <td>+0.3</td>
+</tr>
+<tr>
+  <td>Qwen2-1.5B-instruct</td>
+  <td>52.4</td>
+  <td>47.1</td>
+  <td>47.5</td>
+  <td>-0.4</td>
+  <td>45.2</td>
+  <td>44.5</td>
+  <td>+0.7</td>
+</tr>
+<tr>
+  <td>Gemma-2-2B</td>
+  <td>51.3</td>
+  <td>43.9</td>
+  <td>42.4</td>
+  <td>+1.5</td>
+  <td>30.5</td>
+  <td>29.4</td>
+  <td>+0.9</td>
+</tr>
+<tr>
+  <td>Qwen2.5-0.5B-instruct</td>
+  <td>24.1</td>
+  <td>41.9</td>
+  <td>41.1</td>
+  <td>+0.8</td>
+  <td>36.0</td>
+  <td>34.9</td>
+  <td>+1.1</td>
+</tr>
+<tr>
+  <td>Internlm-2-chat-1.8b</td>
+  <td>47.1</td>
+  <td>40.5</td>
+  <td>39.4</td>
+  <td>+1.1</td>
+  <td>41.2</td>
+  <td>39.8</td>
+  <td>+1.4</td>
+</tr>
+<tr>
+  <td>Qwen2-0.5B-instruct</td>
+  <td>37.9</td>
+  <td>38.3</td>
+  <td>38.3</td>
+  <td>+0.0</td>
+  <td>33.5</td>
+  <td>33.5</td>
+  <td>+0.0</td>
+</tr>
+  </tbody>
+</table>
+
+## 5. Data Construction Pipeline
+![Fig3](./Figures/Fig_3.png)
+The pipeline involves (1) MCQ Collection to gather a diverse set of questions; (2) MCQ Cleaning to ensure quality; (3) Difficulty Sampling to ensure an appropriate difficulty distribution for questions; (4) LLMs checking: The LLMs, including GPT-4o, Gemini, and Claude, are reviewing the accuracy and safety of the data; and (5) Contamination-Free Processing to prevent data leakage and maintain dataset purity. Ultimately, this process results in the MMLU-CF, consisting of 10,000 questions for the closed-source test set and 10,000 for the open-source validation set.
+
+## 6. Contact
+For any inquiries or concerns, feel free to reach out to us via Email: [Qihao Zhao](qhzhaoo@gmail.com) and [Yangyu Huang](yanghuan@microsoft.com).
+
+## 7. Citation
+```
+@misc{zhao2024mmlucfcontaminationfreemultitasklanguage,
+      title={MMLU-CF: A Contamination-free Multi-task Language Understanding Benchmark}, 
+      author={Qihao Zhao and Yangyu Huang and Tengchao Lv and Lei Cui and Qinzheng Sun and Shaoguang Mao and Xin Zhang and Ying Xin and Qiufeng Yin and Scarlett Li and Furu Wei},
+      year={2024},
+      eprint={2412.15194},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2412.15194}, 
+}
+```
+
+## 8. License
+This repository is licensed under the [MIT](https://github.com/microsoft/PEACE/blob/main/LICENSE) License.
+The validation dataset of MMLU-CF is subject to the [CDLA-2.0](https://cdla.dev/permissive-2-0/) License.

--- a/opencompass/configs/datasets/mmlu_cf/mmlu_cf_categories.py
+++ b/opencompass/configs/datasets/mmlu_cf/mmlu_cf_categories.py
@@ -1,0 +1,16 @@
+categories = [
+    'Math',
+    'Physics',
+    'Chemistry',
+    'Law',
+    'Engineering',
+    'Other',
+    'Economics',
+    'Health',
+    'Psychology',
+    'Business',
+    'Biology',
+    'Philosophy',
+    'Computer_Science',
+    'History',
+]

--- a/opencompass/configs/datasets/mmlu_cf/mmlu_cf_gen.py
+++ b/opencompass/configs/datasets/mmlu_cf/mmlu_cf_gen.py
@@ -1,0 +1,64 @@
+from mmengine.config import read_base
+from opencompass.openicl.icl_prompt_template import PromptTemplate
+from opencompass.openicl.icl_retriever import FixKRetriever
+from opencompass.openicl.icl_inferencer import GenInferencer
+from opencompass.openicl.icl_evaluator import AccwithDetailsEvaluator
+from opencompass.datasets import MMLUCFDataset
+from opencompass.utils.text_postprocessors import first_option_postprocess
+
+with read_base():
+    from .mmlu_cf_categories import categories
+
+mmlu_cf_reader_cfg = dict(
+    input_columns=['input', 'A', 'B', 'C', 'D'],
+    output_column='target',
+    train_split='dev')
+
+mmlu_cf_datasets = []
+for _name in categories:
+    _hint = f'There is a single choice question. Answer the question by replying A, B, C or D.'
+    mmlu_cf_infer_cfg = dict(
+        ice_template=dict(
+            type=PromptTemplate,
+            template=dict(round=[
+                dict(
+                    role='HUMAN',
+                    prompt=
+                    f'{_hint}\nQuestion: {{input}}\nA. {{A}}\nB. {{B}}\nC. {{C}}\nD. {{D}}\nAnswer: '
+                ),
+                dict(role='BOT', prompt='{target}\n')
+            ]),
+        ),
+        prompt_template=dict(
+            type=PromptTemplate,
+            template=dict(
+                begin='</E>',
+                round=[
+                    dict(
+                        role='HUMAN',
+                        prompt=f'{_hint}\nQuestion: {{input}}\nA. {{A}}\nB. {{B}}\nC. {{C}}\nD. {{D}}\nAnswer: '
+                    ),
+                ],
+            ),
+            ice_token='</E>',
+        ),
+        retriever=dict(type=FixKRetriever, fix_id_list=[0, 1, 2, 3, 4]),
+        inferencer=dict(type=GenInferencer),
+    )
+
+    mmlu_cf_eval_cfg = dict(
+        evaluator=dict(type=AccwithDetailsEvaluator),
+        pred_postprocessor=dict(type=first_option_postprocess, options='ABCD'))
+
+    mmlu_cf_datasets.append(
+        dict(
+            abbr=f'mmlu_cf_{_name}',
+            type=MMLUCFDataset,
+            path='opencompass/mmlu_cf/',
+            name=_name,
+            reader_cfg=mmlu_cf_reader_cfg,
+            infer_cfg=mmlu_cf_infer_cfg,
+            eval_cfg=mmlu_cf_eval_cfg,
+        ))
+
+del _name, _hint

--- a/opencompass/configs/datasets/mmlu_cf/mmlu_cf_val_few_shot.py
+++ b/opencompass/configs/datasets/mmlu_cf/mmlu_cf_val_few_shot.py
@@ -1,0 +1,64 @@
+from mmengine.config import read_base
+from opencompass.openicl.icl_prompt_template import PromptTemplate
+from opencompass.openicl.icl_retriever import FixKRetriever
+from opencompass.openicl.icl_inferencer import GenInferencer
+from opencompass.openicl.icl_evaluator import AccwithDetailsEvaluator
+from opencompass.datasets import MMLUCFDataset
+from opencompass.utils.text_postprocessors import first_option_postprocess
+
+with read_base():
+    from .mmlu_cf_categories import categories
+
+mmlu_cf_reader_cfg = dict(
+    input_columns=['input', 'A', 'B', 'C', 'D'],
+    output_column='target',
+    train_split='dev')
+
+mmlu_cf_datasets = []
+for _name in categories:
+    _hint = f'There is a single choice question (with answers). Answer the question by replying A, B, C or D.'
+    mmlu_cf_infer_cfg = dict(
+        ice_template=dict(
+            type=PromptTemplate,
+            template=dict(round=[
+                dict(
+                    role='HUMAN',
+                    prompt=
+                    f'{_hint}\nQuestion: {{input}}\nA. {{A}}\nB. {{B}}\nC. {{C}}\nD. {{D}}\nAnswer: '
+                ),
+                dict(role='BOT', prompt='{target}\n')
+            ]),
+        ),
+        prompt_template=dict(
+            type=PromptTemplate,
+            template=dict(
+                begin='</E>',
+                round=[
+                    dict(
+                        role='HUMAN',
+                        prompt=f'{_hint}\nQuestion: {{input}}\nA. {{A}}\nB. {{B}}\nC. {{C}}\nD. {{D}}\nAnswer: '
+                    ),
+                ],
+            ),
+            ice_token='</E>',
+        ),
+        retriever=dict(type=FixKRetriever, fix_id_list=[0, 1, 2, 3, 4]),
+        inferencer=dict(type=GenInferencer),
+    )
+
+    mmlu_cf_eval_cfg = dict(
+        evaluator=dict(type=AccwithDetailsEvaluator),
+        pred_postprocessor=dict(type=first_option_postprocess, options='ABCD'))
+
+    mmlu_cf_datasets.append(
+        dict(
+            abbr=f'mmlu_cf_{_name}',
+            type=MMLUCFDataset,
+            path='opencompass/mmlu_cf',
+            name=_name,
+            reader_cfg=mmlu_cf_reader_cfg,
+            infer_cfg=mmlu_cf_infer_cfg,
+            eval_cfg=mmlu_cf_eval_cfg,
+        ))
+
+del _name, _hint

--- a/opencompass/configs/datasets/mmlu_cf/mmlu_cf_val_zero_shot.py
+++ b/opencompass/configs/datasets/mmlu_cf/mmlu_cf_val_zero_shot.py
@@ -1,0 +1,64 @@
+from mmengine.config import read_base
+from opencompass.openicl.icl_prompt_template import PromptTemplate
+from opencompass.openicl.icl_retriever import ZeroRetriever
+from opencompass.openicl.icl_inferencer import GenInferencer
+from opencompass.openicl.icl_evaluator import AccwithDetailsEvaluator
+from opencompass.datasets import MMLUCFDataset
+from opencompass.utils.text_postprocessors import first_option_postprocess
+
+with read_base():
+    from .mmlu_cf_categories import categories
+
+mmlu_cf_reader_cfg = dict(
+    input_columns=['input', 'A', 'B', 'C', 'D'],
+    output_column='target',
+    train_split='dev')
+
+mmlu_cf_datasets = []
+for _name in categories:
+    _hint = f'There is a single choice question (with answers). Answer the question by replying A, B, C or D.'
+    mmlu_cf_infer_cfg = dict(
+        ice_template=dict(
+            type=PromptTemplate,
+            template=dict(round=[
+                dict(
+                    role='HUMAN',
+                    prompt=
+                    f'{_hint}\nQuestion: {{input}}\nA. {{A}}\nB. {{B}}\nC. {{C}}\nD. {{D}}\nAnswer: '
+                ),
+                dict(role='BOT', prompt='{target}\n')
+            ]),
+        ),
+        prompt_template=dict(
+            type=PromptTemplate,
+            template=dict(
+                begin='</E>',
+                round=[
+                    dict(
+                        role='HUMAN',
+                        prompt=f'{_hint}\nQuestion: {{input}}\nA. {{A}}\nB. {{B}}\nC. {{C}}\nD. {{D}}\nAnswer: '
+                    ),
+                ],
+            ),
+            ice_token='</E>',
+        ),
+        retriever=dict(type=ZeroRetriever),
+        inferencer=dict(type=GenInferencer),
+    )
+
+    mmlu_cf_eval_cfg = dict(
+        evaluator=dict(type=AccwithDetailsEvaluator),
+        pred_postprocessor=dict(type=first_option_postprocess, options='ABCD'))
+
+    mmlu_cf_datasets.append(
+        dict(
+            abbr=f'mmlu_cf_{_name}',
+            type=MMLUCFDataset,
+            path='opencompass/mmlu_cf',
+            name=_name,
+            reader_cfg=mmlu_cf_reader_cfg,
+            infer_cfg=mmlu_cf_infer_cfg,
+            eval_cfg=mmlu_cf_eval_cfg,
+        ))
+
+del _name, _hint

--- a/opencompass/configs/summarizers/chat_OC15.py
+++ b/opencompass/configs/summarizers/chat_OC15.py
@@ -2,6 +2,7 @@ from mmengine.config import read_base
 
 with read_base():
     from .groups.mmlu import mmlu_summary_groups
+    from .groups.mmlu_cf import mmlu_cf_summary_groups
     from .groups.cmmlu import cmmlu_summary_groups
     from .groups.ceval import ceval_summary_groups
     from .groups.bbh import bbh_summary_groups
@@ -12,7 +13,8 @@ other_summary_groups = [
     {
         'name': 'average',
         'subsets': [
-            ['mmlu', 'naive_average'],
+            ['mmlu', 'naive_average']
+            ['mmlu_cf', 'naive_average'],
             ['cmmlu', 'naive_average'],
             ['ceval', 'naive_average'],
             ['GaokaoBench', 'weighted_average'],
@@ -38,6 +40,7 @@ summarizer = dict(
         ['average', 'naive_average'],
         ['mmlu', 'naive_average'],
         ['cmmlu', 'naive_average'],
+        ['mmlu_cf', 'naive_average'],    
         ['ceval', 'naive_average'],
         ['GaokaoBench', 'weighted_average'],
         ['triviaqa_wiki_1shot', 'score'],

--- a/opencompass/configs/summarizers/chat_OC15_multi_faceted.py
+++ b/opencompass/configs/summarizers/chat_OC15_multi_faceted.py
@@ -3,6 +3,7 @@ from opencompass.summarizers import MultiFacetedSummarizer
 
 with read_base():
     from .groups.mmlu import mmlu_summary_groups
+    from .groups.mmlu_cf import mmlu_cf_summary_groups
     from .groups.cmmlu import cmmlu_summary_groups
     from .groups.ceval import ceval_summary_groups
     from .groups.bbh import bbh_summary_groups
@@ -13,6 +14,7 @@ other_summary_groups = [
         'name': 'average',
         'subsets': [
             ['mmlu', 'naive_average'],
+            ['mmlu_cf', 'naive_average'],
             ['cmmlu', 'naive_average'],
             ['ceval', 'naive_average'],
             ['GaokaoBench', 'weighted_average'],
@@ -36,6 +38,7 @@ other_summary_groups = [
 overall_dataset_abbrs = [
     ['average', 'naive_average'],
     ['mmlu', 'naive_average'],
+    ['mmlu_cf', 'naive_average'],
     ['cmmlu', 'naive_average'],
     ['ceval', 'naive_average'],
     ['GaokaoBench', 'weighted_average'],
@@ -52,6 +55,11 @@ overall_dataset_abbrs = [
     ['sanitized_mbpp', 'score'],
     ['GPQA_diamond', 'accuracy'],
     ['IFEval', 'Prompt-level-strict-accuracy'],
+]
+
+mmlu_cf_summary_groups_dict = {g['name']: g['subsets'] for g in mmlu_cf_summary_groups}
+mmlu_cf_dataset_abbrs = [
+    ['mmlu_cf', 'naive_average'],
 ]
 
 mmlu_summary_groups_dict = {g['name']: g['subsets'] for g in mmlu_summary_groups}
@@ -127,6 +135,7 @@ summarizer = dict(
     dataset_abbrs_list=[
         {'name': 'overall', 'dataset_abbrs': overall_dataset_abbrs},
         {'name': 'mmlu', 'dataset_abbrs': mmlu_dataset_abbrs},
+        {'name': 'mmlu_cf', 'dataset_abbrs': mmlu_cf_dataset_abbrs},
         {'name': 'cmmlu', 'dataset_abbrs': cmmlu_dataset_abbrs},
         {'name': 'ceval', 'dataset_abbrs': ceval_dataset_abbrs},
         {'name': 'bbh', 'dataset_abbrs': bbh_dataset_abbrs},

--- a/opencompass/configs/summarizers/example.py
+++ b/opencompass/configs/summarizers/example.py
@@ -3,6 +3,7 @@ from mmengine.config import read_base
 with read_base():
     from .groups.agieval import agieval_summary_groups
     from .groups.mmlu import mmlu_summary_groups
+    from .groups.mmlu_cf import mmlu_cf_summary_groups
     from .groups.cmmlu import cmmlu_summary_groups
     from .groups.ceval import ceval_summary_groups
     from .groups.bbh import bbh_summary_groups

--- a/opencompass/configs/summarizers/groups/mmlu_cf.py
+++ b/opencompass/configs/summarizers/groups/mmlu_cf.py
@@ -1,0 +1,5 @@
+categories = ['Computer Science', 'Math', 'Physics', 'Chemistry', 'Law', 'Engineering', 'Other', 'Economics', 'Health', 'Psychology', 'Business', 'Biology', 'Philosophy',  'History']
+
+mmlu_cf_summary_groups = [
+    {'name': 'mmlu_cf', 'subsets': ['mmlu_cf_' + c.replace(' ', '_') for c in categories]},
+]

--- a/opencompass/configs/summarizers/mmlu_cf.py
+++ b/opencompass/configs/summarizers/mmlu_cf.py
@@ -1,0 +1,25 @@
+from mmengine.config import read_base
+
+with read_base():
+    from .groups.mmlu_cf import mmlu_cf_summary_groups
+
+summarizer = dict(
+    dataset_abbrs=[
+        'mmlu_cf',
+        'mmlu_cf_Biology',
+        'mmlu_cf_Business',
+        'mmlu_cf_Chemistry',
+        'mmlu_cf_Computer_Science',
+        'mmlu_cf_Economics',
+        'mmlu_cf_Engineering',
+        'mmlu_cf_Health',
+        'mmlu_cf_History',
+        'mmlu_cf_Law',
+        'mmlu_cf_Math',
+        'mmlu_cf_Philosophy',
+        'mmlu_cf_Physics',
+        'mmlu_cf_Psychology',
+        'mmlu_cf_Other',
+    ],
+    summary_groups=sum([v for k, v in locals().items() if k.endswith('_summary_groups')], []),
+)

--- a/opencompass/datasets/__init__.py
+++ b/opencompass/datasets/__init__.py
@@ -28,6 +28,7 @@ from .clozeTest_maxmin import *  # noqa: F401, F403
 from .cluewsc import *  # noqa: F401, F403
 from .cmb import *  # noqa: F401, F403
 from .cmmlu import *  # noqa: F401, F403
+from .mmlu_cf import *  # noqa: F401, F403
 from .cmnli import *  # noqa: F401, F403
 from .cmo_fib import *  # noqa: F401, F403
 from .cmrc import *  # noqa: F401, F403

--- a/opencompass/datasets/mmlu_cf.py
+++ b/opencompass/datasets/mmlu_cf.py
@@ -1,0 +1,72 @@
+import csv
+import json
+import os.path as osp
+from os import environ
+
+from datasets import Dataset, DatasetDict
+
+from opencompass.registry import LOAD_DATASET
+from opencompass.utils import get_data_path
+
+from .base import BaseDataset
+
+
+@LOAD_DATASET.register_module()
+class MMLUCFDataset(BaseDataset):
+
+    @staticmethod
+    def load(path: str, name: str):
+        path = get_data_path(path)
+        dataset = DatasetDict()
+        if environ.get('DATASET_SOURCE') == 'ModelScope':
+            from modelscope import MsDataset
+            for split in ['dev', 'test']:
+                # 从 ModelScope 加载数据
+                if split == 'test':
+                    _split = 'val'
+                    ms_dataset = MsDataset.load(path,
+                                            subset_name=name,
+                                            split=_split)
+                else:
+                    ms_dataset = MsDataset.load(path,
+                                            subset_name=name,
+                                            split=split)
+                
+                dataset_list = []
+                for i, line in ms_dataset:
+                    if i == 0:  # 跳过第一行
+                        continue
+                    dataset_list.append({
+                        'input': line['question'],
+                        'A': line['choices'][0],
+                        'B': line['choices'][1],
+                        'C': line['choices'][2],
+                        'D': line['choices'][3],
+                        'target': 'ABCD'[line['answer']],
+                    })
+                dataset[split] = Dataset.from_list(dataset_list)
+        else:
+            for split in ['dev', 'test']:
+                if split == 'test':
+                    _split = 'val'
+                    filename = osp.join(path, _split, f'{name}_{_split}.csv')
+                else:
+                    filename = osp.join(path, split, f'{name}_{split}.csv')
+                raw_data = []
+                with open(filename, encoding='utf-8') as f:
+                    reader = csv.reader(f)
+                    next(reader)  
+                    for row in reader:
+
+                        assert len(row) == 6
+                        raw_data.append({
+                            'input': row[0],
+                            'A': row[1],
+                            'B': row[2],
+                            'C': row[3],
+                            'D': row[4],
+                            'target': row[5],
+                        })
+                dataset[split] = Dataset.from_list(raw_data)
+        return dataset
+

--- a/opencompass/utils/datasets_info.py
+++ b/opencompass/utils/datasets_info.py
@@ -181,10 +181,16 @@ DATASETS_MAPPING = {
         "hf_id": "opencompass/mmlu",
         "local": "./data/mmlu/",
     },
+    # MMLU_CF
+    "opencompass/mmlu_cf": {
+        "ms_id": "",
+        "hf_id": "",
+        "local": "./data/mmlu_cf/",
+    },
     # MMLU_PRO
     "opencompass/mmlu_pro": {
         "ms_id": "",
-        "hf_id": "",
+        "hf_id": "microsoft/MMLU-CF",
         "local": "./data/mmlu_pro",
     },
     # NQ

--- a/opencompass/utils/datasets_info.py
+++ b/opencompass/utils/datasets_info.py
@@ -184,13 +184,13 @@ DATASETS_MAPPING = {
     # MMLU_CF
     "opencompass/mmlu_cf": {
         "ms_id": "",
-        "hf_id": "",
+        "hf_id": "microsoft/MMLU-CF",
         "local": "./data/mmlu_cf/",
     },
     # MMLU_PRO
     "opencompass/mmlu_pro": {
         "ms_id": "",
-        "hf_id": "microsoft/MMLU-CF",
+        "hf_id": "",
         "local": "./data/mmlu_pro",
     },
     # NQ


### PR DESCRIPTION
## Motivation

This PR introduces support for the MMLU-CF benchmark. The motivation behind this contribution is to enhance the evaluation of large language models by integrating the MMLU-CF dataset, a contamination-free and more challenging multiple-choice question benchmark. This dataset contains 10K questions each for the validation set and test set, covering 14 disciplines. By implementing this, the goal is to provide a more accurate and fair evaluation, ensuring that the test results are more reliable and transparent, following the improved guidelines set by Microsoft Research.

## Modification

The modification in this PR includes integrating the MMLU-CF dataset into the evaluation pipeline. This involves:
- Ensuring compatibility with existing evaluation frameworks for easy comparison with other benchmarks like MMLU.
- Implementing the necessary rules and configurations to handle the dataset’s unique validation splits.

## BC-breaking (Optional)

No, this modification does not break backward compatibility. 

## Use cases (Optional)

This PR introduces a new feature by supporting the MMLU-CF benchmark. 

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
