### PR TITLE
updates the dependency `PyExt` for python3.11\3.12 support

### DIFF
--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -18,7 +18,7 @@ ltp
 # Math
 math-verify
 # Taco, apps Dataset
-pyext
+git+https://github.com/ShaohonChen/PyExt.git@a95f488490fc57ec17d0c00a99c6bc0a4726824f
 # Law Bench
 pypinyin
 # RULER

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -24,7 +24,7 @@ opencv-python-headless
 pandas<2.0.0
 prettytable
 protobuf
-pyext
+git+https://github.com/ShaohonChen/PyExt.git@a95f488490fc57ec17d0c00a99c6bc0a4726824f
 python-Levenshtein
 rank_bm25==0.2.2
 rapidfuzz


### PR DESCRIPTION
## Description

This PR updates the dependency `PyExt` to use a [pyext compatibility fork](https://github.com/ShaohonChen/PyExt/tree/py311support) that supports **Python 3.10, 3.11, and 3.12**, ensuring compatibility with modern Python versions while maintaining existing functionality.

The original PyExt package was incompatible with Python 3.10+, causing runtime errors below:

```bash
Collecting pyext (from opencompass[full])
  Using cached https://mirror.nju.edu.cn/pypi/web/packages/b0/be/9b6005ac644aaef022527ce49617263379e49dbdbd433d1d3dd66d71f570/pyext-0.7.tar.gz (7.8 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [9 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-1og4krgl/pyext_1a3ddddf62ac4f1f8409c43687c247bb/setup.py", line 6, in <module>
          import pyext
        File "/tmp/pip-install-1og4krgl/pyext_1a3ddddf62ac4f1f8409c43687c247bb/pyext.py", line 117, in <module>
          oargspec = inspect.getargspec
                     ^^^^^^^^^^^^^^^^^^
      AttributeError: module 'inspect' has no attribute 'getargspec'. Did you mean: 'getargs'?
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

Note: I’ve also submitted a PR to the original PyExt repository ([https://github.com/refi64/PyExt/pull/5](https://github.com/refi64/PyExt/pull/5)) to address these issues upstream, including previously overlooked ipykernel support. This fork serves as an interim solution until upstream merges the changes.

## Modification

- Replaced the original `PyExt` dependency in `requirements/runtime.txt` and `requirements/extra.txt` with the forked version:
  ```txt
  git+https://github.com/ShaohonChen/PyExt.git@a95f488490fc57ec17d0c00a99c6bc0a4726824f
  ```

Testing

Tested locally with Python 3.10, 3.11, and 3.12.

Tested locally with ipykernel be installed, which 

## Related Issues

Closes #1976 

Close #1234 

References: [https://github.com/refi64/PyExt/pull/5](https://github.com/refi64/PyExt/pull/5)
