### PR TITLE
add `tmp_dir` in runners  to avoid hard-code

### DIFF
--- a/opencompass/runners/base.py
+++ b/opencompass/runners/base.py
@@ -15,18 +15,21 @@ class BaseRunner:
         task (ConfigDict): Task type config.
         debug (bool): Whether to run in debug mode.
         lark_bot_url (str): Lark bot url.
+        tmp_dir (str): The directory to store temporary files.
     """
 
     def __init__(self,
                  task: ConfigDict,
                  debug: bool = False,
-                 lark_bot_url: str = None):
+                 lark_bot_url: str = None,
+                 tmp_dir: str = 'tmp'):
         self.task_cfg = Config(task)
         self.debug = debug
         if lark_bot_url:
             self.lark_reporter = LarkReporter(lark_bot_url)
         else:
             self.lark_reporter = None
+        self.tmp_dir = tmp_dir
 
     def __call__(self, tasks: List[Dict[str, Any]]):
         """Launch multiple tasks and summarize the results.

--- a/opencompass/runners/dlc.py
+++ b/opencompass/runners/dlc.py
@@ -33,6 +33,9 @@ class DLCRunner(BaseRunner):
         retry (int): Number of retries when job failed. Default: 2.
         debug (bool): Whether to run in debug mode. Default: False.
         lark_bot_url (str): Lark bot url. Default: None.
+        keep_tmp_file (bool): Whether to keep the temporary file.
+            Default: True.
+        tmp_dir (str): The directory to store temporary files. Default: 'tmp'.
     """
 
     def __init__(
@@ -45,8 +48,12 @@ class DLCRunner(BaseRunner):
         debug: bool = False,
         lark_bot_url: str = None,
         keep_tmp_file: bool = True,
+        tmp_dir: str = 'tmp',
     ):
-        super().__init__(task=task, debug=debug, lark_bot_url=lark_bot_url)
+        super().__init__(task=task,
+                         debug=debug,
+                         lark_bot_url=lark_bot_url,
+                         tmp_dir=tmp_dir)
         self.aliyun_cfg = aliyun_cfg
         self.max_num_workers = max_num_workers
         self.retry = retry
@@ -114,12 +121,13 @@ class DLCRunner(BaseRunner):
                     break
 
         # Dump task config to file
-        mmengine.mkdir_or_exist('tmp/')
+        mmengine.mkdir_or_exist(self.tmp_dir)
         # Using uuid to avoid filename conflict
         import uuid
 
         uuid_str = str(uuid.uuid4())
-        param_file = f'tmp/{uuid_str}_params.py'
+        param_file = f'{uuid_str}_params.py'
+        param_file = osp.join(self.tmp_dir, param_file)
         pwd = os.getcwd()
         try:
             cfg.dump(param_file)

--- a/opencompass/runners/local_api.py
+++ b/opencompass/runners/local_api.py
@@ -161,6 +161,8 @@ class LocalAPIRunner(BaseRunner):
             Defaults to 16.
         debug (bool): Whether to run in debug mode.
         lark_bot_url (str): Lark bot url.
+        tmp_dir (str): The directory to store temporary files.
+            Defaults to 'tmp'.
     """
 
     def __init__(self,
@@ -168,8 +170,12 @@ class LocalAPIRunner(BaseRunner):
                  concurrent_users: int,
                  max_num_workers: int = 16,
                  debug: bool = False,
-                 lark_bot_url: str = None):
-        super().__init__(task=task, debug=debug, lark_bot_url=lark_bot_url)
+                 lark_bot_url: str = None,
+                 tmp_dir: str = 'tmp'):
+        super().__init__(task=task,
+                         debug=debug,
+                         lark_bot_url=lark_bot_url,
+                         tmp_dir=tmp_dir)
         self.max_num_workers = max_num_workers
         self.concurrent_users = concurrent_users
         assert task['type'] in [
@@ -194,8 +200,9 @@ class LocalAPIRunner(BaseRunner):
                 task = TASKS.build(dict(cfg=task, type=self.task_cfg['type']))
                 task_name = task.name
                 # get cmd
-                mmengine.mkdir_or_exist('tmp/')
-                param_file = f'tmp/{os.getpid()}_params.py'
+                mmengine.mkdir_or_exist(self.tmp_dir)
+                param_file = f'{os.getpid()}_params.py'
+                param_file = osp.join(self.tmp_dir, param_file)
                 try:
                     task.cfg.dump(param_file)
                     cmd = task.get_command(cfg_path=param_file,

--- a/opencompass/runners/slurm.py
+++ b/opencompass/runners/slurm.py
@@ -33,6 +33,8 @@ class SlurmRunner(BaseRunner):
         lark_bot_url (str): Lark bot url. Defaults to None.
         extra_command (List, optional): Extra slurm command.
             For example ['-c 12', '-w node1']. Defaults to None.
+        tmp_dir (str): The directory to store temporary files.
+            Defaults to 'tmp'.
     """
 
     def __init__(self,
@@ -44,8 +46,12 @@ class SlurmRunner(BaseRunner):
                  qos: str = None,
                  debug: bool = False,
                  lark_bot_url: str = None,
-                 extra_command: Optional[List[str]] = None):
-        super().__init__(task=task, debug=debug, lark_bot_url=lark_bot_url)
+                 extra_command: Optional[List[str]] = None,
+                 tmp_dir: str = 'tmp'):
+        super().__init__(task=task,
+                         debug=debug,
+                         lark_bot_url=lark_bot_url,
+                         tmp_dir=tmp_dir)
         self.max_num_workers = max_num_workers
         self.retry = retry
         self.partition = partition
@@ -93,8 +99,9 @@ class SlurmRunner(BaseRunner):
         task_name = task.name
 
         # Dump task config to file
-        mmengine.mkdir_or_exist('tmp/')
-        param_file = f'tmp/{os.getpid()}_params.py'
+        mmengine.mkdir_or_exist(self.tmp_dir)
+        param_file = f'{os.getpid()}_params.py'
+        param_file = osp.join(self.tmp_dir, param_file)
         try:
             cfg.dump(param_file)
 

--- a/opencompass/runners/slurm_sequential.py
+++ b/opencompass/runners/slurm_sequential.py
@@ -47,6 +47,10 @@ class SlurmSequentialRunner(BaseRunner):
         lark_bot_url (str): Lark bot url. Defaults to None.
         extra_command (List, optional): Extra slurm command.
             For example ['-c 12', '-w node1']. Defaults to None.
+        keep_tmp_file (bool): Whether to keep the temporary file. Defaults to
+            False.
+        tmp_dir (str): The directory to store temporary files.
+            Defaults to 'tmp'.
     """
 
     def __init__(self,
@@ -60,8 +64,12 @@ class SlurmSequentialRunner(BaseRunner):
                  debug: bool = False,
                  lark_bot_url: str = None,
                  extra_command: Optional[List[str]] = None,
-                 keep_tmp_file: bool = False):
-        super().__init__(task=task, debug=debug, lark_bot_url=lark_bot_url)
+                 keep_tmp_file: bool = False,
+                 tmp_dir: str = 'tmp'):
+        super().__init__(task=task,
+                         debug=debug,
+                         lark_bot_url=lark_bot_url,
+                         tmp_dir=tmp_dir)
         self.max_num_workers = max_num_workers
         self.retry = retry
         self.partition = partition
@@ -172,11 +180,12 @@ class SlurmSequentialRunner(BaseRunner):
         task_name = self.task_prefix + task_name
 
         # Dump task config to file
-        mmengine.mkdir_or_exist('tmp/')
+        mmengine.mkdir_or_exist(self.tmp_dir)
         # Using uuid to avoid filename conflict
         import uuid
         uuid_str = str(uuid.uuid4())
-        param_file = f'tmp/{uuid_str}_params.py'
+        param_file = f'{uuid_str}_params.py'
+        param_file = osp.join(self.tmp_dir, param_file)
         process = None
         try:
             cfg.dump(param_file)

--- a/opencompass/runners/volc.py
+++ b/opencompass/runners/volc.py
@@ -36,6 +36,9 @@ class VOLCRunner(BaseRunner):
         retry (int): Number of retries when job failed. Default: 2.
         debug (bool): Whether to run in debug mode. Default: False.
         lark_bot_url (str): Lark bot url. Default: None.
+        keep_tmp_file (bool): Whether to keep the temporary file. Default:
+            False.
+        tmp_dir (str): The directory to store temporary files. Default: 'tmp'.
     """
 
     def __init__(self,
@@ -48,8 +51,12 @@ class VOLCRunner(BaseRunner):
                  retry: int = 2,
                  debug: bool = False,
                  lark_bot_url: str = None,
-                 keep_tmp_file: bool = True):
-        super().__init__(task=task, debug=debug, lark_bot_url=lark_bot_url)
+                 keep_tmp_file: bool = True,
+                 tmp_dir: str = 'tmp'):
+        super().__init__(task=task,
+                         debug=debug,
+                         lark_bot_url=lark_bot_url,
+                         tmp_dir=tmp_dir)
         self.volcano_cfg = volcano_cfg
         self.max_num_workers = max_num_workers
         self.retry = retry
@@ -101,13 +108,15 @@ class VOLCRunner(BaseRunner):
         # Build up VCC command
         pwd = os.getcwd()
         # Dump task config to file
-        mmengine.mkdir_or_exist('tmp/')
+        mmengine.mkdir_or_exist(self.tmp_dir)
         # Using uuid to avoid filename conflict
         import uuid
         uuid_str = str(uuid.uuid4())
-        param_file = f'{pwd}/tmp/{uuid_str}_params.py'
+        param_file = f'{uuid_str}_params.py'
+        param_file = osp.join(self.tmp_dir, param_file)
 
-        volc_cfg_file = f'{pwd}/tmp/{uuid_str}_cfg.yaml'
+        volc_cfg_file = f'{uuid_str}_cfg.yaml'
+        volc_cfg_file = osp.join(self.tmp_dir, volc_cfg_file)
         volc_cfg = self._choose_flavor(num_gpus)
         with open(volc_cfg_file, 'w') as fp:
             yaml.dump(volc_cfg, fp, sort_keys=False)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The tmp file is hard-coded in the `runners`, add `tmp_dir`, which can setting in the config.

## Modification

add `tmp_dir` in the runner.

## BC-breaking (Optional)

seems no BC-breaking. if not set tmp_dir, it will use default `tmp` setting.