### PR TITLE
More stable MBPP evaluation

### DIFF
--- a/opencompass/datasets/mbpp.py
+++ b/opencompass/datasets/mbpp.py
@@ -4,7 +4,6 @@ import itertools
 import json
 import multiprocessing
 import os.path as osp
-import regex as re
 import signal
 import tempfile
 from collections import defaultdict
@@ -13,6 +12,7 @@ from os import environ
 from typing import List, Sequence, Union
 
 import numpy as np
+import regex as re
 from datasets import Dataset, DatasetDict, concatenate_datasets, load_dataset
 
 from opencompass.openicl.icl_evaluator import BaseEvaluator


### PR DESCRIPTION
This PR improves the stability of the evaluation process for the MBPP dataset.

## Motivation

There were two key issues affecting the robustness and reliability of the evaluation:

1. **Regex performance**:
   The regex pattern [`[r'(.*)\s*```.*'](https://github.com/open-compass/opencompass/blob/aa2b89b6f8b7c5448e47ed1aa3f12b04da1ff123/opencompass/datasets/mbpp.py#L327)`](https://github.com/open-compass/opencompass/blob/aa2b89b6f8b7c5448e47ed1aa3f12b04da1ff123/opencompass/datasets/mbpp.py#L327) occasionally hangs when processing predictions containing excessive trailing whitespace. This is likely due to catastrophic backtracking. To mitigate this, I replaced the standard `re` module with the `regex` module, which supports timeouts, and set a hard timeout of 10 seconds.

2. **Multiprocessing issue**:
   The following error was encountered:
   `AttributeError: Can't pickle local object 'execution.<locals>._execution'`
   This occurs because the `ProcessPoolExecutor` cannot pickle local (non-global) functions. The fix is to move the `_execution` function to the global scope so it can be properly serialized.

## Modifications

1. Replaced `re` with `regex` and added a 10-second timeout to [`[regex.search](https://github.com/open-compass/opencompass/blob/aa2b89b6f8b7c5448e47ed1aa3f12b04da1ff123/opencompass/datasets/mbpp.py#L333)`](https://github.com/open-compass/opencompass/blob/aa2b89b6f8b7c5448e47ed1aa3f12b04da1ff123/opencompass/datasets/mbpp.py#L333).
2. Moved the `_execution` function [[from here](https://github.com/open-compass/opencompass/blob/aa2b89b6f8b7c5448e47ed1aa3f12b04da1ff123/opencompass/datasets/mbpp.py#L403C1-L418C33)](https://github.com/open-compass/opencompass/blob/aa2b89b6f8b7c5448e47ed1aa3f12b04da1ff123/opencompass/datasets/mbpp.py#L403C1-L418C33) to the global scope to resolve the pickling issue.

## Backward Compatibility

This change is not breaking. However, note that introducing a regex timeout may cause differences in evaluation results for cases where the timeout is triggered.
