### PR TITLE
Add GrandPhysics dataset

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ exclude: |
     )
 repos:
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 7.2.0
     hooks:
       - id: flake8
         exclude: |
@@ -29,7 +29,7 @@ repos:
                 examples/
             )
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.5
+    rev: 6.0.1
     hooks:
       - id: isort
         exclude: |
@@ -47,7 +47,7 @@ repos:
                 examples/
             )
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.1
+    rev: v2.4.1
     hooks:
       - id: codespell
         exclude: |
@@ -58,7 +58,7 @@ repos:
                 examples/
             )
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
         exclude: |
@@ -81,7 +81,7 @@ repos:
       - id: mixed-line-ending
         args: ["--fix=lf"]
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.9
+    rev: 0.7.22
     hooks:
       - id: mdformat
         args: ["--number", "--table-width", "200"]
@@ -91,7 +91,7 @@ repos:
           - linkify-it-py
         exclude: configs/
   - repo: https://github.com/myint/docformatter
-    rev: v1.3.1
+    rev: v1.7.7
     hooks:
       - id: docformatter
         args: ["--in-place", "--wrap-descriptions", "79"]
@@ -117,7 +117,7 @@ repos:
           - --root_folder
           - opencompass/configs/datasets
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.23.1
+    rev: v8.26.0
     hooks:
     -   id: gitleaks
         entry: "gitleaks dir"

--- a/dataset-index.yml
+++ b/dataset-index.yml
@@ -1113,3 +1113,9 @@
     paper: https://arxiv.org/pdf/2203.14371
     configpath: opencompass/configs/datasets/medmcqa/medmcqa_gen.py
     configpath_llmjudge: opencompass/configs/datasets/medmcqa/medmcqa_llmjudge_gen.py
+- grand_physics:
+    name: GrandPhysics
+    category: Science
+    paper: ''
+    configpath: ''
+    configpath_llmjudge: opencompass/configs/datasets/GrandPhysics/GrandPhysics_llm_judge_gen.py

--- a/opencompass/configs/datasets/GrandPhysics/GrandPhysics_llm_judge_gen.py
+++ b/opencompass/configs/datasets/GrandPhysics/GrandPhysics_llm_judge_gen.py
@@ -1,0 +1,93 @@
+from opencompass.openicl.icl_prompt_template import PromptTemplate
+from opencompass.openicl.icl_retriever import ZeroRetriever
+from opencompass.openicl.icl_inferencer import GenInferencer
+from opencompass.datasets import (
+    GrandPhysicsDataset,
+    generic_llmjudge_postprocess,
+)
+from opencompass.evaluator import GenericLLMEvaluator
+
+GRADER_TEMPLATE = """
+    Please as a grading expert, judge whether the final answers given by the candidates below are consistent with the standard answers, that is, whether the candidates answered correctly.
+
+    Here are some evaluation criteria:
+    1. Please refer to the given standard answer. You don't need to re-generate the answer to the question because the standard answer has been given. You only need to judge whether the candidate's answer is consistent with the standard answer according to the form of the question. Don't try to answer the original question. You can assume that the standard answer is definitely correct.
+    2. Because the candidate's answer may be different from the standard answer in the form of expression, before making a judgment, please understand the question and the standard answer first, and then judge whether the candidate's answer is correct, but be careful not to try to answer the original question.
+    3. Some questions may include multiple sub questions and sub answers. Each sub answer is given after a guide character in the form of <Answer 1:> or <Answer 2:>, etc. Please note that only when all sub predictions given in prediction correspond one-to-one with the answer and are all correct, will the prediction be considered correct; otherwise, it will be considered incorrect.
+    4. Some answers may be expressed in different ways, such as some answers may be a mathematical expression, some answers may be a textual description, as long as the meaning expressed is the same. And some formulas are expressed in different ways, but they are equivalent and correct.
+    5. The final answers in the prediction are generally given with \\boxed{}. If you cannot find sufficient \\boxed{} in the prediction, please try to find matching answers from other places within the prediction as much as possible.
+
+    Please judge whether the following answers are consistent with the standard answer based on the above criteria. Grade the predicted answer of this new question as one of:
+    A: All Sub Predictions Are Correct
+    B: Not Every Sub Predictions is Correct
+    Just return the letters "A" or "B", with no text around it.
+
+    Here is your task. Simply reply with either A, B. Don't apologize or correct yourself if there was a mistake; we are just trying to grade the answer.
+
+    <Original Question Begin>: \n{input}\n<Original Question End>\n\n
+    <Gold Target Begin>: \n{target}\n<Gold Target End>\n\n
+    <Predicted Answer Begin>: \n{prediction}\n<Predicted End>\n\n
+
+    Judging the correctness of candidates' answers:
+""".strip()
+
+grand_physics_reader_cfg = dict(input_columns=['input'], output_column='target')
+
+
+grand_physics_infer_cfg = dict(
+    prompt_template=dict(
+        type=PromptTemplate,
+        template=dict(
+            round=[
+                dict(
+                    role='HUMAN',
+                    prompt=f'Answer the given question step by step. Begin by explaining your reasoning process clearly. Conclude by providing the final answers at the end in LaTeX boxed format. Think step by step before answering. It should be noted that the question may include multiple sub questions, please ensure that each question is answered in order.\n\nQ: {{input}}\nA: ',
+                )
+            ]
+        ),
+    ),
+    retriever=dict(type=ZeroRetriever),
+    inferencer=dict(type=GenInferencer),
+)
+
+grand_physics_eval_cfg = dict(
+    evaluator=dict(
+        type=GenericLLMEvaluator,
+        prompt_template=dict(
+            type=PromptTemplate,
+            template=dict(
+                begin=[
+                    dict(
+                        role='SYSTEM',
+                        fallback_role='HUMAN',
+                        prompt="You are a helpful assistant who evaluates the correctness and quality of models' outputs.",
+                    )
+                ],
+                round=[
+                    dict(role='HUMAN', prompt=GRADER_TEMPLATE),
+                ],
+            ),
+        ),
+        dataset_cfg=dict(
+            type=GrandPhysicsDataset,
+            path='opencompass/GrandPhysics',
+            abbr='GrandPhysics',
+            reader_cfg=grand_physics_reader_cfg,
+        ),
+        judge_cfg=dict(),
+        dict_postprocessor=dict(type=generic_llmjudge_postprocess),
+    ),
+    pred_role='BOT',
+)
+
+grand_physics_dataset = [
+    dict(
+        abbr='GrandPhysics',
+        type=GrandPhysicsDataset,
+        path='opencompass/GrandPhysics',
+        reader_cfg=grand_physics_reader_cfg,
+        infer_cfg=grand_physics_infer_cfg,
+        eval_cfg=grand_physics_eval_cfg,
+    )
+]
+

--- a/opencompass/datasets/__init__.py
+++ b/opencompass/datasets/__init__.py
@@ -57,6 +57,7 @@ from .GaokaoBench import *  # noqa: F401, F403
 from .generic import *  # noqa: F401, F403
 from .govrepcrs import *  # noqa: F401, F403
 from .gpqa import *  # noqa: F401, F403
+from .grand_physics import *  # noqa: F401, F403
 from .gsm8k import *  # noqa: F401, F403
 from .gsm_hard import *  # noqa: F401, F403
 from .hellaswag import *  # noqa: F401, F403

--- a/opencompass/datasets/grand_physics.py
+++ b/opencompass/datasets/grand_physics.py
@@ -1,0 +1,20 @@
+import os
+
+from datasets import load_dataset
+
+from opencompass.datasets.base import BaseDataset
+from opencompass.registry import LOAD_DATASET
+from opencompass.utils import get_data_path
+
+
+@LOAD_DATASET.register_module()
+class GrandPhysicsDataset(BaseDataset):
+
+    @staticmethod
+    def load(path: str, **kwargs):
+        path = get_data_path(path)
+        path = os.path.join(path)
+        data = load_dataset(path)['train']
+        data = data.rename_columns({'problem': 'input', 'answer': 'target'})
+
+        return data

--- a/opencompass/utils/datasets_info.py
+++ b/opencompass/utils/datasets_info.py
@@ -466,6 +466,11 @@ DATASETS_MAPPING = {
         "hf_id": "",
         "local": "./data/medbullets/medbullets.csv",
     },
+    "opencompass/GrandPhysics": {
+        "ms_id": "",
+        "hf_id": "",
+        "local": "./data/GrandPhysics/GrandPhysics_50_questions.json",
+    },
 
 }
 


### PR DESCRIPTION

## Motivation

This PR adds support for the GrandPhysics dataset to OpenCompass. GrandPhysics is a evaluation dataset (not yet publicly available) built from A Grand Dictionary of Physics Problems and Solutions (物理学大题典). Dataset file need to be uploaded to OSS.
[GrandPhysics_50_questions.json](https://github.com/user-attachments/files/20435197/GrandPhysics_50_questions.json)


## Modification

1. Dataset file: opencompass/datasets/grand_physics.py

2. Dataset evaluation configuration: opencompass/configs/datasets/GrandPhysics/GrandPhysics_llm_judge_gen.py


## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
