### PR TITLE
Fix PHYbench

### DIFF
--- a/opencompass/configs/datasets/PHYBench/phybench_gen.py
+++ b/opencompass/configs/datasets/PHYBench/phybench_gen.py
@@ -15,7 +15,7 @@ phybench_infer_cfg = dict(
             round=[
                 dict(
                     role='HUMAN',
-                    prompt=f'Solve the following physics problem and return only the final result as a clean LaTeX expression. No explanation. No text.\n\nQuestion: {{input}}\nAnswer: ',
+                    prompt='Solve the following physics problem and return only the final result as a clean LaTeX expression.Remember to put your final answer within \\boxed{}.\n\nQuestion: {{input}}\nAnswer: ',
                 ),
             ],
         ),

--- a/opencompass/datasets/phybench/box_extract.py
+++ b/opencompass/datasets/phybench/box_extract.py
@@ -1,0 +1,29 @@
+def extract_boxed_latex(prediction: str) -> str:
+    """
+    提取 \\boxed{...} 中的表达式（支持嵌套括号）。
+    """
+    start = prediction.find("\\boxed{")
+    if start == -1:
+        lines = prediction.strip().split('\n')
+        return lines[-1].strip() if lines else prediction.strip()
+
+    idx = start + len("\\boxed{")
+    brace_count = 1
+    content = []
+
+    while idx < len(prediction):
+        char = prediction[idx]
+        if char == '{':
+            brace_count += 1
+        elif char == '}':
+            brace_count -= 1
+            if brace_count == 0:
+                break
+        content.append(char)
+        idx += 1
+
+    if brace_count == 0:
+        return ''.join(content).strip()
+    else:
+        lines = prediction.strip().split('\n')
+        return lines[-1].strip() if lines else prediction.strip()

--- a/opencompass/datasets/phybench/box_extract.py
+++ b/opencompass/datasets/phybench/box_extract.py
@@ -1,13 +1,11 @@
 def extract_boxed_latex(prediction: str) -> str:
-    """
-    提取 \\boxed{...} 中的表达式（支持嵌套括号）。
-    """
-    start = prediction.find("\\boxed{")
+    """提取 \\boxed{...} 中的表达式（支持嵌套括号）。"""
+    start = prediction.find('\\boxed{')
     if start == -1:
         lines = prediction.strip().split('\n')
         return lines[-1].strip() if lines else prediction.strip()
 
-    idx = start + len("\\boxed{")
+    idx = start + len('\\boxed{')
     brace_count = 1
     content = []
 

--- a/opencompass/datasets/phybench/phybench.py
+++ b/opencompass/datasets/phybench/phybench.py
@@ -9,6 +9,7 @@ from opencompass.datasets.phybench.EED import EED
 from opencompass.openicl import BaseEvaluator
 from opencompass.registry import ICL_EVALUATORS, LOAD_DATASET
 from opencompass.utils import get_data_path
+from opencompass.datasets.phybench.box_extract import extract_boxed_latex
 
 
 @LOAD_DATASET.register_module()
@@ -34,6 +35,7 @@ class MathEEDEvaluator(BaseEvaluator):
     def score(self, predictions, references):
         scores = []
         for pred, ref in zip(predictions, references):
-            score, _, _, _ = EED(ref, pred)
+            pred_clean = extract_boxed_latex(pred)
+            score, _, _, _ = EED(ref, pred_clean)
             scores.append(score)
         return {'accuracy': sum(scores) / len(scores)}

--- a/opencompass/datasets/phybench/phybench.py
+++ b/opencompass/datasets/phybench/phybench.py
@@ -5,11 +5,11 @@ import os.path as osp
 from datasets import Dataset
 
 from opencompass.datasets.base import BaseDataset
+from opencompass.datasets.phybench.box_extract import extract_boxed_latex
 from opencompass.datasets.phybench.EED import EED
 from opencompass.openicl import BaseEvaluator
 from opencompass.registry import ICL_EVALUATORS, LOAD_DATASET
 from opencompass.utils import get_data_path
-from opencompass.datasets.phybench.box_extract import extract_boxed_latex
 
 
 @LOAD_DATASET.register_module()
@@ -34,8 +34,15 @@ class MathEEDEvaluator(BaseEvaluator):
 
     def score(self, predictions, references):
         scores = []
+        details = []
         for pred, ref in zip(predictions, references):
             pred_clean = extract_boxed_latex(pred)
             score, _, _, _ = EED(ref, pred_clean)
             scores.append(score)
-        return {'accuracy': sum(scores) / len(scores)}
+            details.append({
+                'pred': pred,
+                'ref': ref,
+                'pred_clean': pred_clean,
+                'score': score
+            })
+        return {'accuracy': sum(scores) / len(scores), 'details': details}


### PR DESCRIPTION
Motivation
This PR fixes a scoring bug in the phybench evaluation. The current implementation had an error in how scores were computed or aggregated, leading to incorrect evaluation results. The goal is to ensure that the benchmark results are accurate and consistent with the expected logic of the task.

Modification
Fixed the scoring logic in the phybench benchmark.

Adjusted the evaluation script to correctly calculate the metrics.


