### PR TITLE
fixed math evaluator in aime2024

### DIFF
--- a/opencompass/configs/datasets/aime2024/aime2024_gen_17d799.py
+++ b/opencompass/configs/datasets/aime2024/aime2024_gen_17d799.py
@@ -1,7 +1,7 @@
 from opencompass.openicl.icl_prompt_template import PromptTemplate
 from opencompass.openicl.icl_retriever import ZeroRetriever
 from opencompass.openicl.icl_inferencer import GenInferencer
-from opencompass.openicl.icl_evaluator import MATHEvaluator
+from opencompass.evaluator import MATHVerifyEvaluator
 from opencompass.datasets import Aime2024Dataset
 
 
@@ -25,7 +25,7 @@ aime2024_infer_cfg = dict(
 )
 
 aime2024_eval_cfg = dict(
-    evaluator=dict(type=MATHEvaluator)
+    evaluator=dict(type=MATHVerifyEvaluator)
 )
 
 aime2024_datasets = [


### PR DESCRIPTION

## Motivation

A recent commit replaced `MATHEvaluator` with `MATHVerifyEvaluator`. However, this change was not reflected in `opencompass/configs/datasets/aime2024/aime2024_gen_17d799.py`, which serves as the default configuration for `aime2024_gen.py`.

As a result, running evaluations for aime2024 previously resulted in errors due to the missing evaluator reference.

## Modification

Replaced `MATHEvaluator` with `MATHVerifyEvaluator` in the affected configuration file.

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
