### PR TITLE
[Fix] livecodebench serialization and timeout errors

### DIFF
--- a/opencompass/datasets/livecodebench/evaluator.py
+++ b/opencompass/datasets/livecodebench/evaluator.py
@@ -19,21 +19,22 @@ from .livecodebench import LCBCodeGenerationDataset
 from .pass_k_utils import compute_metrics_from_results
 
 
+def _temp_run(sample, generation, debug, result, metadata_list, timeout):
+    from .testing_util import run_test
+    res, metadata = run_test(sample,
+                             test=generation,
+                             debug=debug,
+                             timeout=timeout)
+    result.append(res)
+    metadata_list.append(metadata)
+
+
 def codegen_check_correctness(sample, generation, timeout, debug=True):
     """Check correctness of code generation with a global timeout.
 
     The global timeout is to catch some extreme/rare cases not handled by the
     timeouts inside `run_test`
     """
-
-    def _temp_run(sample, generation, debug, result, metadata_list, timeout):
-        from .testing_util import run_test
-        res, metadata = run_test(sample,
-                                 test=generation,
-                                 debug=debug,
-                                 timeout=timeout)
-        result.append(res)
-        metadata_list.append(metadata)
 
     manager = multiprocessing.Manager()
     result = manager.list()
@@ -337,7 +338,7 @@ def evaluate_score(args) -> list[bool]:
         else:
             code_to_execute = f'{BASE_IMPORTS}\n{c}\nassert {o} == {g}'
             execution_results.append(
-                codeexecute_check_correctness(code_to_execute, 3))
+                codeexecute_check_correctness(code_to_execute, 30))
     if len(execution_results) == 0:
         execution_results = [False] * len(gs)
     return execution_results


### PR DESCRIPTION
## Motivation

While evaluating with Livecodebench (LCB), I encountered two issues:

1. The existing timeout of 3 seconds frequently results in timeouts when using `ProcessPoolExecutor()` with its default number of processes. To address this, I increased the timeout to 30 seconds.

2. Using `ProcessPoolExecutor()` with a local function causes a serialization error. This is resolved by moving the local function to the global namespace.

## Modifications

1. Moved `_temp_run` to the global namespace.
2. Increased the timeout in `codeexecute_check_correctness` from 3 seconds to 30 seconds.

## Backward Compatibility

These changes are backward compatible. However, note that increasing the timeout may cause some tests to pass that would have previously failed due to exceeding the shorter timeout.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
