### PR TITLE
[fix] switch think mode

### DIFF
--- a/opencompass/models/turbomind_with_tf_above_v4_33.py
+++ b/opencompass/models/turbomind_with_tf_above_v4_33.py
@@ -142,7 +142,12 @@ class TurboMindModelwithChatTemplate(BaseModel):
             messages = _format_with_fast_chat_template(messages, self.fastchat_template)
         else:
             # NOTE: DeepSeek-R1 series model's chat template will add <think> after the
-            messages = [self.tokenizer.apply_chat_template(m, add_generation_prompt=True, tokenize=False) for m in messages]
+            if 'enable_thinking' in self.gen_config:
+                messages = [self.tokenizer.apply_chat_template(
+                    m, add_generation_prompt=True, tokenize=False, enable_thinking=self.gen_config['enable_thinking']) for m in messages]
+            else:
+                messages = [self.tokenizer.apply_chat_template(
+                    m, add_generation_prompt=True, tokenize=False) for m in messages]
             # LMDeploy tokenize prompts by AutoTokenizer with its default parameter "add_special_token=True"
             # OC add bos_token in the prompt, which requires tokenizing prompts using "add_speicial_token=False"
             # But LMDeploy doesn't have "add_speicial_token" in the pipeline API. So, we remove bos_token


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The model outputs <think> content regardless of whether the enable_thinking parameter is set to False or True. This indicates that the parameter is not being correctly applied or processed, causing the model to consistently include the "thinking" section in its output.

## Modification

To address this, the enable_thinking parameter needs to be correctly passed into the tokenizer.apply_chat_template function. The proposed fix involves modifying opencompass/models/turbomind_with_tf_above_v4_33.py to correctly handle this parameter:

```
if 'enable_thinking' in self.gen_config:
    messages = [self.tokenizer.apply_chat_template(m, add_generation_prompt=True, tokenize=False, enable_thinking=self.gen_config['enable_thinking']) for m in messages]
else:
    messages = [self.tokenizer.apply_chat_template(m, add_generation_prompt=True, tokenize=False) for m in messages]
```

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
