### PR TITLE
Fix auto register `LocalAPIRunner` module

### DIFF
--- a/opencompass/runners/__init__.py
+++ b/opencompass/runners/__init__.py
@@ -1,5 +1,6 @@
 from .dlc import *  # noqa: F401, F403
 from .local import *  # noqa: F401, F403
+from .local_api import *  # noqa: F401, F403
 from .rjob import *  # noqa: F401, F403
 from .slurm import *  # noqa: F401, F403
 from .slurm_sequential import *  # noqa: F401, F403


### PR DESCRIPTION
Currently, Module `LocalAPIRunner` will not be registered to the runner registry. So, if use string-format config file `type="LocalAPIRunner"` will raise KeyError

Error info:
>  KeyError: 'LocalAPIRunner is not in the opencompass::runner registry. Please check whether the value of `LocalAPIRunner` is correct or it was registered as expected. More details can be found at https://mmengine.readthedocs.io/en/latest/advanced_tutorials/config.html#import-the-custom-module'

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix auto register `LocalAPIRunner` module, so that we can use `LocalAPIRunner` runner by string in config file.

## Modification

add `from .local_api import *` in runer's __init__ file

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
