### PR TITLE
Fix duplicate engine config update in TurboMindModelwithChatTemplate

### DIFF
--- a/opencompass/models/turbomind_with_tf_above_v4_33.py
+++ b/opencompass/models/turbomind_with_tf_above_v4_33.py
@@ -64,7 +64,6 @@ class TurboMindModelwithChatTemplate(BaseModel):
             else:
                 raise ValueError(f'expected Dict or ConfigDict engine_config but got {type(engine_config)}')
 
-            _engine_config.update(engine_config.to_dict())
             self.pipe = self._build_pipe(path, backend, _engine_config)
         else:
             self.pipe = None


### PR DESCRIPTION
The `_engine_config.update(engine_config.to_dict())` line is executed after the conditional block. This causes an `AttributeError` when `engine_config` is a plain Python `dict` (as `dict` objects have no `.to_dict()` method), resulting in an AttributeError. 

When `engine_config` is a `ConfigDict`, the operation is also redundant.