### PR TITLE
[Fix] Rename smolinstruct_pp_acc_0_shot_instruct dataset list as {}_datasets

### DIFF
--- a/opencompass/configs/datasets/SmolInstruct/smolinstruct_pp_acc_0_shot_instruct.py
+++ b/opencompass/configs/datasets/SmolInstruct/smolinstruct_pp_acc_0_shot_instruct.py
@@ -28,8 +28,8 @@ name_dict = {
     'SIDER': 'property_prediction-sider',
 }
 
-pp_acc_datasets_0shot_instruct = []
-mini_pp_acc_datasets_0shot_instruct = []
+pp_acc_0shot_instruct_datasets = []
+mini_pp_acc_0shot_instruct_datasets = []
 for _name in pp_acc_hint_dict:
     _hint = pp_acc_hint_dict[_name]
 
@@ -51,7 +51,7 @@ for _name in pp_acc_hint_dict:
         pred_postprocessor=dict(type=smolinstruct_acc_0shot_postprocess)
     )
 
-    pp_acc_datasets_0shot_instruct.append(
+    pp_acc_0shot_instruct_datasets.append(
         dict(
             abbr=f'PP-{_name}-0shot-instruct',
             type=SmolInstructDataset,
@@ -61,7 +61,7 @@ for _name in pp_acc_hint_dict:
             infer_cfg=pp_acc_infer_cfg,
             eval_cfg=pp_acc_eval_cfg,
         ))
-    mini_pp_acc_datasets_0shot_instruct.append(
+    mini_pp_acc_0shot_instruct_datasets.append(
         dict(
             abbr=f'PP-{_name}-0shot-instruct-mini',
             type=SmolInstructDataset,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

smolinstruct_pp_acc_0_shot_instruct的config文件中的数据集列表名称不是{}_datasets格式，导致用`opencompass --datasets smolinstruct_pp_acc_0_shot_instruct`评测时无法正常读取这些数据集。

## Modification

修改了列表名称为预期的{}_datasets，使之可以被正常评测
