### PR TITLE
[Fix] CEval ModelScope load and HF generate for causal LMs

### DIFF
--- a/opencompass/datasets/ceval.py
+++ b/opencompass/datasets/ceval.py
@@ -20,7 +20,8 @@ class CEvalDataset(BaseDataset):
         dataset = {}
         if environ.get('DATASET_SOURCE') == 'ModelScope':
             from modelscope import MsDataset
-            dataset = MsDataset.load(dataset_name=path, subset_name=name)
+            dataset = MsDataset.load(
+                dataset_name=path, subset_name=name, trust_remote_code=True)
         else:
             for split in ['dev', 'val', 'test']:
                 filename = osp.join(path, split, f'{name}_{split}.csv')
@@ -72,7 +73,8 @@ class CEvalDatasetClean(BaseDataset):
         dataset = {}
         if environ.get('DATASET_SOURCE') == 'ModelScope':
             from modelscope import MsDataset
-            dataset = MsDataset.load(dataset_name=path, subset_name=name)
+            dataset = MsDataset.load(
+                dataset_name=path, subset_name=name, trust_remote_code=True)
             # 向该数据添加 'is_clean' 字段
             annotations = CEvalDatasetClean.load_contamination_annotations(
                 path, 'val')

--- a/opencompass/models/huggingface_above_v4_33.py
+++ b/opencompass/models/huggingface_above_v4_33.py
@@ -478,6 +478,8 @@ class HuggingFacewithChatTemplate(BaseModel):
         self.logger.info(generation_kwargs)
 
         # step-2: conduct model forward to generate output
+        # LLaMA and some causal LMs do not accept token_type_ids in generate().
+        tokens.pop('token_type_ids', None)
         outputs = self.model.generate(**tokens, **generation_kwargs)
         outputs = outputs[:, tokens['input_ids'].shape[1]:]
 
@@ -580,6 +582,8 @@ class HuggingFaceBaseModel(HuggingFacewithChatTemplate):
         generation_kwargs['pad_token_id'] = self.tokenizer.pad_token_id
 
         # step-2: conduct model forward to generate output
+        # LLaMA and some causal LMs do not accept token_type_ids in generate().
+        tokens.pop('token_type_ids', None)
         outputs = self.model.generate(**tokens, **generation_kwargs)
         outputs = outputs[:, tokens['input_ids'].shape[1]:]
 


### PR DESCRIPTION
Pass trust_remote_code=True to MsDataset.load for CEval when using ModelScope.

Drop token_type_ids before model.generate() for LLaMA-like models that reject it.

Made-with: Cursor

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
