### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/opencompass/configs/models/minimax/minimax_m2_5.py
+++ b/opencompass/configs/models/minimax/minimax_m2_5.py
@@ -1,0 +1,20 @@
+from opencompass.models import MiniMaxAPI
+
+api_meta_template = dict(round=[
+    dict(role='HUMAN', api_role='HUMAN'),
+    dict(role='BOT', api_role='BOT', generate=True),
+], )
+
+models = [
+    dict(
+        abbr='MiniMax-M2.5',
+        type=MiniMaxAPI,
+        path='MiniMax-M2.5',
+        key='ENV',
+        meta_template=api_meta_template,
+        query_per_second=2,
+        max_out_len=4096,
+        max_seq_len=204800,
+        batch_size=8,
+    ),
+]

--- a/opencompass/configs/models/minimax/minimax_m2_5_highspeed.py
+++ b/opencompass/configs/models/minimax/minimax_m2_5_highspeed.py
@@ -1,0 +1,20 @@
+from opencompass.models import MiniMaxAPI
+
+api_meta_template = dict(round=[
+    dict(role='HUMAN', api_role='HUMAN'),
+    dict(role='BOT', api_role='BOT', generate=True),
+], )
+
+models = [
+    dict(
+        abbr='MiniMax-M2.5-highspeed',
+        type=MiniMaxAPI,
+        path='MiniMax-M2.5-highspeed',
+        key='ENV',
+        meta_template=api_meta_template,
+        query_per_second=2,
+        max_out_len=4096,
+        max_seq_len=204800,
+        batch_size=8,
+    ),
+]

--- a/opencompass/configs/models/minimax/minimax_m2_7.py
+++ b/opencompass/configs/models/minimax/minimax_m2_7.py
@@ -1,0 +1,20 @@
+from opencompass.models import MiniMaxAPI
+
+api_meta_template = dict(round=[
+    dict(role='HUMAN', api_role='HUMAN'),
+    dict(role='BOT', api_role='BOT', generate=True),
+], )
+
+models = [
+    dict(
+        abbr='MiniMax-M2.7',
+        type=MiniMaxAPI,
+        path='MiniMax-M2.7',
+        key='ENV',
+        meta_template=api_meta_template,
+        query_per_second=2,
+        max_out_len=4096,
+        max_seq_len=204800,
+        batch_size=8,
+    ),
+]

--- a/opencompass/configs/models/minimax/minimax_m2_7_highspeed.py
+++ b/opencompass/configs/models/minimax/minimax_m2_7_highspeed.py
@@ -7,9 +7,9 @@ api_meta_template = dict(round=[
 
 models = [
     dict(
-        abbr='MiniMax-M2.5-highspeed',
+        abbr='MiniMax-M2.7-highspeed',
         type=MiniMaxAPI,
-        path='MiniMax-M2.5-highspeed',
+        path='MiniMax-M2.7-highspeed',
         key='ENV',
         meta_template=api_meta_template,
         query_per_second=2,

--- a/opencompass/configs/models/minimax/minimax_m3.py
+++ b/opencompass/configs/models/minimax/minimax_m3.py
@@ -7,14 +7,14 @@ api_meta_template = dict(round=[
 
 models = [
     dict(
-        abbr='MiniMax-M2.5',
+        abbr='MiniMax-M3',
         type=MiniMaxAPI,
-        path='MiniMax-M2.5',
+        path='MiniMax-M3',
         key='ENV',
         meta_template=api_meta_template,
         query_per_second=2,
         max_out_len=4096,
-        max_seq_len=204800,
+        max_seq_len=524288,
         batch_size=8,
     ),
 ]

--- a/opencompass/models/__init__.py
+++ b/opencompass/models/__init__.py
@@ -26,7 +26,8 @@ from .interntrain import InternTrain  # noqa: F401
 from .krgpt_api import KrGPT  # noqa: F401
 from .lightllm_api import LightllmAPI, LightllmChatAPI  # noqa: F401
 from .llama2 import Llama2, Llama2Chat  # noqa: F401
-from .minimax_api import MiniMax, MiniMaxChatCompletionV2  # noqa: F401
+from .minimax_api import MiniMax, MiniMaxAPI  # noqa: F401
+from .minimax_api import MiniMaxChatCompletionV2  # noqa: F401
 from .mistral_api import Mistral  # noqa: F401
 from .mixtral import Mixtral  # noqa: F401
 from .modelscope import ModelScope, ModelScopeCausalLM  # noqa: F401

--- a/opencompass/models/minimax_api.py
+++ b/opencompass/models/minimax_api.py
@@ -1,3 +1,5 @@
+import os
+import re
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, List, Optional, Union
@@ -10,17 +12,24 @@ from .base_api import BaseAPIModel
 
 PromptType = Union[PromptList, str]
 
+MINIMAX_API_BASE = 'https://api.minimax.io/v1/chat/completions'
+
 
 class MiniMax(BaseAPIModel):
-    """Model wrapper around MiniMax.
+    """Model wrapper around MiniMax (legacy chatcompletion_pro API).
 
-    Documentation: https://api.minimax.chat/document/guides/chat-pro
+    .. deprecated::
+        Use :class:`MiniMaxAPI` instead, which supports the latest
+        OpenAI-compatible ``/v1/chat/completions`` endpoint and newer
+        models (MiniMax-M2.7, MiniMax-M2.5, etc.).
+
+    Documentation: https://platform.minimaxi.com/document/guides/chat-pro
 
     Args:
         path (str): The name of MiniMax model.
-            e.g. `abab5.5-chat`
+            e.g. ``abab5.5-chat``
         model_type (str): The type of the model
-            e.g. `chat`
+            e.g. ``chat``
         group_id (str): The id of group(like the org ID of group)
         key (str): Authorization key.
         query_per_second (int): The maximum queries allowed per second
@@ -185,12 +194,15 @@ class MiniMax(BaseAPIModel):
 class MiniMaxChatCompletionV2(BaseAPIModel):
     """Model wrapper around MiniMax ChatCompletionV2.
 
-    Documentation:
+    .. deprecated::
+        Use :class:`MiniMaxAPI` instead, which provides the same
+        functionality with additional features (environment variable
+        support, temperature clamping, thinking tag handling).
 
     Args:
         path (str): The name of MiniMax model.
-            e.g. `moonshot-v1-32k`
         key (str): Authorization key.
+        url (str): The API endpoint URL.
         query_per_second (int): The maximum queries allowed per second
             between two consecutive calls of the API. Defaults to 1.
         max_seq_len (int): Unused here.
@@ -204,7 +216,7 @@ class MiniMaxChatCompletionV2(BaseAPIModel):
         self,
         path: str,
         key: str,
-        url: str,
+        url: str = MINIMAX_API_BASE,
         query_per_second: int = 2,
         max_seq_len: int = 2048,
         meta_template: Optional[Dict] = None,
@@ -348,6 +360,247 @@ class MiniMaxChatCompletionV2(BaseAPIModel):
             else:
                 print(messages, response)
                 print('请求失败，状态码:', raw_response)
+                time.sleep(1)
+
+            max_num_retries += 1
+
+        raise RuntimeError(raw_response)
+
+
+class MiniMaxAPI(BaseAPIModel):
+    """Model wrapper around MiniMax's OpenAI-compatible API.
+
+    Supports the latest MiniMax models including MiniMax-M2.7,
+    MiniMax-M2.5, and MiniMax-M2.5-highspeed via the
+    ``/v1/chat/completions`` endpoint.
+
+    Documentation: https://platform.minimaxi.com/document/ChatCompletion%20v2
+
+    Args:
+        path (str): The name of MiniMax model.
+            e.g. ``MiniMax-M2.7``, ``MiniMax-M2.5``,
+            ``MiniMax-M2.5-highspeed``
+        key (str or List[str]): Authorization key(s). When set to
+            ``'ENV'``, the key will be fetched from the environment
+            variable ``$MINIMAX_API_KEY``. If it's a list, the keys
+            will be used in round-robin manner. Defaults to ``'ENV'``.
+        url (str): The API endpoint URL. Defaults to
+            ``'https://api.minimax.io/v1/chat/completions'``.
+        query_per_second (int): The maximum queries allowed per second
+            between two consecutive calls of the API. Defaults to 2.
+        max_seq_len (int): The maximum sequence length. Defaults to
+            204800 (MiniMax supports up to 204K context).
+        meta_template (Dict, optional): The model's meta prompt
+            template if needed, in case the requirement of injecting or
+            wrapping of any meta instructions.
+        retry (int): Number of retries if the API call fails.
+            Defaults to 2.
+        temperature (float, optional): Sampling temperature. MiniMax
+            accepts values in [0, 1.0]. If not specified, the server
+            default is used.
+        think_tag (str, optional): The closing tag used to separate
+            reasoning content from the final answer. Defaults to
+            ``'</think>'``.
+        system_prompt (str, optional): System prompt to prepend.
+            Defaults to empty string.
+    """
+
+    def __init__(
+        self,
+        path: str = 'MiniMax-M2.7',
+        key: Union[str, List[str]] = 'ENV',
+        url: str = MINIMAX_API_BASE,
+        query_per_second: int = 2,
+        max_seq_len: int = 204800,
+        meta_template: Optional[Dict] = None,
+        retry: int = 2,
+        temperature: Optional[float] = None,
+        think_tag: str = '</think>',
+        system_prompt: str = '',
+    ):
+        super().__init__(path=path,
+                         max_seq_len=max_seq_len,
+                         query_per_second=query_per_second,
+                         meta_template=meta_template,
+                         retry=retry)
+
+        if isinstance(key, str):
+            if key == 'ENV':
+                if 'MINIMAX_API_KEY' not in os.environ:
+                    raise ValueError('MiniMax API key is not set. '
+                                     'Please set the MINIMAX_API_KEY '
+                                     'environment variable.')
+                self.keys = os.getenv('MINIMAX_API_KEY').split(',')
+            else:
+                self.keys = [key]
+        else:
+            self.keys = key
+
+        self.key_ctr = 0
+        self.url = url
+        self.model = path
+        self.temperature = temperature
+        self.think_tag = think_tag
+        self.system_prompt = system_prompt
+
+    def _get_headers(self) -> dict:
+        """Get request headers with the next API key."""
+        key = self.keys[self.key_ctr % len(self.keys)]
+        self.key_ctr += 1
+        return {
+            'Content-Type': 'application/json',
+            'Authorization': f'Bearer {key}',
+        }
+
+    def generate(
+        self,
+        inputs: List[PromptType],
+        max_out_len: int = 512,
+    ) -> List[str]:
+        """Generate results given a list of inputs.
+
+        Args:
+            inputs (List[PromptType]): A list of strings or PromptDicts.
+                The PromptDict should be organized in OpenCompass'
+                API format.
+            max_out_len (int): The maximum length of the output.
+
+        Returns:
+            List[str]: A list of generated strings.
+        """
+        with ThreadPoolExecutor() as executor:
+            results = list(
+                executor.map(self._generate, inputs,
+                             [max_out_len] * len(inputs)))
+        self.flush()
+        return results
+
+    def _generate(
+        self,
+        input: PromptType,
+        max_out_len: int = 512,
+    ) -> str:
+        """Generate results given an input.
+
+        Args:
+            inputs (PromptType): A string or PromptDict.
+                The PromptDict should be organized in OpenCompass'
+                API format.
+            max_out_len (int): The maximum length of the output.
+
+        Returns:
+            str: The generated string.
+        """
+        assert isinstance(input, (str, PromptList))
+
+        if isinstance(input, str):
+            messages = [{'role': 'user', 'content': input}]
+        else:
+            messages = []
+            msg_buffer, last_role = [], None
+            for item in input:
+                item['role'] = 'assistant' if item['role'] == 'BOT' \
+                    else 'user'
+                if item['role'] != last_role and last_role is not None:
+                    messages.append({
+                        'content': '\n'.join(msg_buffer),
+                        'role': last_role
+                    })
+                    msg_buffer = []
+                msg_buffer.append(item['prompt'])
+                last_role = item['role']
+            messages.append({
+                'content': '\n'.join(msg_buffer),
+                'role': last_role
+            })
+
+        if self.system_prompt:
+            messages.insert(0, {
+                'role': 'system',
+                'content': self.system_prompt
+            })
+
+        data = {
+            'model': self.model,
+            'messages': messages,
+            'max_tokens': max_out_len,
+        }
+
+        if self.temperature is not None:
+            # MiniMax accepts temperature in [0, 1.0]
+            data['temperature'] = max(0, min(self.temperature, 1.0))
+
+        max_num_retries = 0
+        while max_num_retries < self.retry:
+            self.acquire()
+            headers = self._get_headers()
+            try:
+                raw_response = requests.request('POST',
+                                                url=self.url,
+                                                headers=headers,
+                                                json=data)
+            except Exception as err:
+                print('Request Error:{}'.format(err))
+                time.sleep(2)
+                continue
+
+            try:
+                response = raw_response.json()
+            except Exception as err:
+                print('Response Error:{}'.format(err))
+                response = None
+            self.release()
+
+            if response is None:
+                print('Connection error, reconnect.')
+                self.wait()
+                continue
+
+            if raw_response.status_code == 200:
+                try:
+                    choice = response['choices'][0]['message']
+                    msg = choice.get('content', '')
+
+                    # Handle reasoning content (think tag)
+                    reasoning = choice.get('reasoning_content', '')
+                    if reasoning and self.think_tag:
+                        msg = reasoning + self.think_tag + msg
+
+                    # Strip inline <think>...</think> tags if present
+                    if not reasoning and msg and self.think_tag:
+                        msg = re.sub(r'<think>.*?</think>\s*', '', msg,
+                                     flags=re.DOTALL)
+
+                    self.logger.debug(f'Generated: {msg}')
+                    return msg
+                except Exception:
+                    code = response.get('base_resp', {}).get('status_code')
+                    if code == 1002:
+                        self.logger.debug('Rate limit, wait for 1s')
+                        time.sleep(1)
+                        continue
+                    elif code == 1026:
+                        return 'The request was rejected because new risk'
+                    elif code == 1027:
+                        return 'The request was rejected because high risk'
+                    self.logger.debug(f'Resp 200, Error: {response}')
+                    pass
+
+            elif raw_response.status_code == 401:
+                print('Authentication failed: invalid API key')
+                continue
+            elif raw_response.status_code == 400:
+                print(messages, response)
+                print('Request failed, status:', raw_response.status_code)
+                msg = 'The request was rejected because high risk'
+                return msg
+            elif raw_response.status_code == 429:
+                print('Rate limited, waiting 5s...')
+                time.sleep(5)
+                continue
+            else:
+                print(messages, response)
+                print('Request failed, status:', raw_response.status_code)
                 time.sleep(1)
 
             max_num_retries += 1

--- a/opencompass/models/minimax_api.py
+++ b/opencompass/models/minimax_api.py
@@ -21,7 +21,7 @@ class MiniMax(BaseAPIModel):
     .. deprecated::
         Use :class:`MiniMaxAPI` instead, which supports the latest
         OpenAI-compatible ``/v1/chat/completions`` endpoint and newer
-        models (MiniMax-M2.7, MiniMax-M2.5, etc.).
+        models (MiniMax-M3, MiniMax-M2.7, etc.).
 
     Documentation: https://platform.minimaxi.com/document/guides/chat-pro
 
@@ -370,16 +370,16 @@ class MiniMaxChatCompletionV2(BaseAPIModel):
 class MiniMaxAPI(BaseAPIModel):
     """Model wrapper around MiniMax's OpenAI-compatible API.
 
-    Supports the latest MiniMax models including MiniMax-M2.7,
-    MiniMax-M2.5, and MiniMax-M2.5-highspeed via the
+    Supports the latest MiniMax models including MiniMax-M3,
+    MiniMax-M2.7, and MiniMax-M2.7-highspeed via the
     ``/v1/chat/completions`` endpoint.
 
     Documentation: https://platform.minimaxi.com/document/ChatCompletion%20v2
 
     Args:
         path (str): The name of MiniMax model.
-            e.g. ``MiniMax-M2.7``, ``MiniMax-M2.5``,
-            ``MiniMax-M2.5-highspeed``
+            e.g. ``MiniMax-M3``, ``MiniMax-M2.7``,
+            ``MiniMax-M2.7-highspeed``
         key (str or List[str]): Authorization key(s). When set to
             ``'ENV'``, the key will be fetched from the environment
             variable ``$MINIMAX_API_KEY``. If it's a list, the keys
@@ -389,7 +389,7 @@ class MiniMaxAPI(BaseAPIModel):
         query_per_second (int): The maximum queries allowed per second
             between two consecutive calls of the API. Defaults to 2.
         max_seq_len (int): The maximum sequence length. Defaults to
-            204800 (MiniMax supports up to 204K context).
+            524288 (MiniMax-M3 supports up to 512K context).
         meta_template (Dict, optional): The model's meta prompt
             template if needed, in case the requirement of injecting or
             wrapping of any meta instructions.
@@ -407,11 +407,11 @@ class MiniMaxAPI(BaseAPIModel):
 
     def __init__(
         self,
-        path: str = 'MiniMax-M2.7',
+        path: str = 'MiniMax-M3',
         key: Union[str, List[str]] = 'ENV',
         url: str = MINIMAX_API_BASE,
         query_per_second: int = 2,
-        max_seq_len: int = 204800,
+        max_seq_len: int = 524288,
         meta_template: Optional[Dict] = None,
         retry: int = 2,
         temperature: Optional[float] = None,

--- a/tests/models/test_minimax_api.py
+++ b/tests/models/test_minimax_api.py
@@ -1,0 +1,568 @@
+"""Unit tests for MiniMax API models."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from opencompass.models.minimax_api import (
+    MINIMAX_API_BASE,
+    MiniMaxAPI,
+    MiniMaxChatCompletionV2,
+)
+
+
+class TestMiniMaxAPI(unittest.TestCase):
+    """Test cases for MiniMaxAPI."""
+
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_initialization_basic(self):
+        """Test basic initialization with ENV key."""
+        model = MiniMaxAPI(
+            path='MiniMax-M2.7',
+            max_seq_len=204800,
+            query_per_second=2,
+        )
+
+        self.assertEqual(model.path, 'MiniMax-M2.7')
+        self.assertEqual(model.model, 'MiniMax-M2.7')
+        self.assertEqual(model.max_seq_len, 204800)
+        self.assertEqual(model.url, MINIMAX_API_BASE)
+        self.assertEqual(model.keys, ['test-key'])
+        self.assertIsNone(model.temperature)
+
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'key1,key2,key3'})
+    def test_initialization_multiple_keys(self):
+        """Test initialization with multiple comma-separated keys."""
+        model = MiniMaxAPI(path='MiniMax-M2.7')
+
+        self.assertEqual(len(model.keys), 3)
+        self.assertEqual(model.keys[0], 'key1')
+        self.assertEqual(model.keys[1], 'key2')
+        self.assertEqual(model.keys[2], 'key3')
+
+    def test_initialization_with_direct_key(self):
+        """Test initialization with a direct API key."""
+        model = MiniMaxAPI(
+            path='MiniMax-M2.5',
+            key='my-direct-key',
+        )
+
+        self.assertEqual(model.keys, ['my-direct-key'])
+
+    def test_initialization_with_key_list(self):
+        """Test initialization with a list of keys."""
+        model = MiniMaxAPI(
+            path='MiniMax-M2.5',
+            key=['key-a', 'key-b'],
+        )
+
+        self.assertEqual(len(model.keys), 2)
+        self.assertEqual(model.keys[0], 'key-a')
+        self.assertEqual(model.keys[1], 'key-b')
+
+    @patch.dict('os.environ', {}, clear=True)
+    def test_initialization_missing_env_key(self):
+        """Test that missing MINIMAX_API_KEY raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            MiniMaxAPI(path='MiniMax-M2.7', key='ENV')
+        self.assertIn('MINIMAX_API_KEY', str(ctx.exception))
+
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_initialization_with_temperature(self):
+        """Test initialization with temperature."""
+        model = MiniMaxAPI(
+            path='MiniMax-M2.7',
+            temperature=0.7,
+        )
+
+        self.assertEqual(model.temperature, 0.7)
+
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_initialization_with_custom_url(self):
+        """Test initialization with custom URL."""
+        custom_url = 'https://custom.minimax.io/v1/chat/completions'
+        model = MiniMaxAPI(
+            path='MiniMax-M2.7',
+            url=custom_url,
+        )
+
+        self.assertEqual(model.url, custom_url)
+
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_default_model(self):
+        """Test that default model is MiniMax-M2.7."""
+        model = MiniMaxAPI()
+
+        self.assertEqual(model.model, 'MiniMax-M2.7')
+
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_key_rotation(self):
+        """Test round-robin key rotation."""
+        model = MiniMaxAPI(
+            path='MiniMax-M2.7',
+            key=['key-1', 'key-2', 'key-3'],
+        )
+
+        headers1 = model._get_headers()
+        headers2 = model._get_headers()
+        headers3 = model._get_headers()
+        headers4 = model._get_headers()
+
+        self.assertEqual(headers1['Authorization'], 'Bearer key-1')
+        self.assertEqual(headers2['Authorization'], 'Bearer key-2')
+        self.assertEqual(headers3['Authorization'], 'Bearer key-3')
+        # Wraps around
+        self.assertEqual(headers4['Authorization'], 'Bearer key-1')
+
+    @patch('opencompass.models.minimax_api.requests')
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_generate_basic(self, mock_requests):
+        """Test basic generate functionality."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'choices': [{
+                'message': {
+                    'content': 'Hello, world!'
+                }
+            }]
+        }
+        mock_requests.request.return_value = mock_response
+
+        model = MiniMaxAPI(path='MiniMax-M2.7')
+        results = model.generate(['Hi there'], max_out_len=100)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0], 'Hello, world!')
+        mock_requests.request.assert_called()
+
+    @patch('opencompass.models.minimax_api.requests')
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_generate_with_reasoning_content(self, mock_requests):
+        """Test generate with reasoning_content in response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'choices': [{
+                'message': {
+                    'content': 'The answer is 42.',
+                    'reasoning_content': 'Let me think step by step...'
+                }
+            }]
+        }
+        mock_requests.request.return_value = mock_response
+
+        model = MiniMaxAPI(
+            path='MiniMax-M2.7',
+            think_tag='</think>',
+        )
+        results = model.generate(['What is the meaning of life?'],
+                                 max_out_len=200)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(
+            results[0],
+            'Let me think step by step...</think>The answer is 42.')
+
+    @patch('opencompass.models.minimax_api.requests')
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_generate_strips_inline_think_tags(self, mock_requests):
+        """Test that inline <think>...</think> tags are stripped."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'choices': [{
+                'message': {
+                    'content':
+                    '<think>internal reasoning here</think>Final answer'
+                }
+            }]
+        }
+        mock_requests.request.return_value = mock_response
+
+        model = MiniMaxAPI(path='MiniMax-M2.7')
+        results = model.generate(['Test'], max_out_len=100)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0], 'Final answer')
+
+    @patch('opencompass.models.minimax_api.requests')
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_generate_with_temperature(self, mock_requests):
+        """Test that temperature is passed in request data."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'choices': [{
+                'message': {
+                    'content': 'Response'
+                }
+            }]
+        }
+        mock_requests.request.return_value = mock_response
+
+        model = MiniMaxAPI(
+            path='MiniMax-M2.7',
+            temperature=0.5,
+        )
+        model.generate(['Hello'], max_out_len=100)
+
+        call_args = mock_requests.request.call_args
+        sent_data = call_args[1]['json']
+        self.assertEqual(sent_data['temperature'], 0.5)
+
+    @patch('opencompass.models.minimax_api.requests')
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_temperature_clamping_high(self, mock_requests):
+        """Test that temperature > 1.0 is clamped to 1.0."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'choices': [{
+                'message': {
+                    'content': 'Response'
+                }
+            }]
+        }
+        mock_requests.request.return_value = mock_response
+
+        model = MiniMaxAPI(
+            path='MiniMax-M2.7',
+            temperature=2.0,
+        )
+        model.generate(['Hello'], max_out_len=100)
+
+        call_args = mock_requests.request.call_args
+        sent_data = call_args[1]['json']
+        self.assertEqual(sent_data['temperature'], 1.0)
+
+    @patch('opencompass.models.minimax_api.requests')
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_temperature_clamping_negative(self, mock_requests):
+        """Test that negative temperature is clamped to 0."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'choices': [{
+                'message': {
+                    'content': 'Response'
+                }
+            }]
+        }
+        mock_requests.request.return_value = mock_response
+
+        model = MiniMaxAPI(
+            path='MiniMax-M2.7',
+            temperature=-0.5,
+        )
+        model.generate(['Hello'], max_out_len=100)
+
+        call_args = mock_requests.request.call_args
+        sent_data = call_args[1]['json']
+        self.assertEqual(sent_data['temperature'], 0)
+
+    @patch('opencompass.models.minimax_api.requests')
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_no_temperature_by_default(self, mock_requests):
+        """Test that temperature is not included when not specified."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'choices': [{
+                'message': {
+                    'content': 'Response'
+                }
+            }]
+        }
+        mock_requests.request.return_value = mock_response
+
+        model = MiniMaxAPI(path='MiniMax-M2.7')
+        model.generate(['Hello'], max_out_len=100)
+
+        call_args = mock_requests.request.call_args
+        sent_data = call_args[1]['json']
+        self.assertNotIn('temperature', sent_data)
+
+    @patch('opencompass.models.minimax_api.requests')
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_generate_with_system_prompt(self, mock_requests):
+        """Test that system prompt is prepended."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'choices': [{
+                'message': {
+                    'content': 'Response'
+                }
+            }]
+        }
+        mock_requests.request.return_value = mock_response
+
+        model = MiniMaxAPI(
+            path='MiniMax-M2.7',
+            system_prompt='You are a helpful assistant.',
+        )
+        model.generate(['Hello'], max_out_len=100)
+
+        call_args = mock_requests.request.call_args
+        sent_data = call_args[1]['json']
+        self.assertEqual(sent_data['messages'][0]['role'], 'system')
+        self.assertEqual(sent_data['messages'][0]['content'],
+                         'You are a helpful assistant.')
+        self.assertEqual(sent_data['messages'][1]['role'], 'user')
+
+    @patch('opencompass.models.minimax_api.requests')
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_generate_multiple_inputs(self, mock_requests):
+        """Test generating with multiple inputs."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'choices': [{
+                'message': {
+                    'content': 'Generated'
+                }
+            }]
+        }
+        mock_requests.request.return_value = mock_response
+
+        model = MiniMaxAPI(path='MiniMax-M2.7')
+        results = model.generate(['Input 1', 'Input 2', 'Input 3'],
+                                 max_out_len=100)
+
+        self.assertEqual(len(results), 3)
+        self.assertTrue(all(r == 'Generated' for r in results))
+
+    @patch('opencompass.models.minimax_api.requests')
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_generate_with_prompt_list(self, mock_requests):
+        """Test generate with PromptList input."""
+        from opencompass.utils.prompt import PromptList
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'choices': [{
+                'message': {
+                    'content': 'Response'
+                }
+            }]
+        }
+        mock_requests.request.return_value = mock_response
+
+        model = MiniMaxAPI(path='MiniMax-M2.7')
+
+        prompt_list = PromptList([
+            {
+                'role': 'HUMAN',
+                'prompt': 'Hello'
+            },
+            {
+                'role': 'BOT',
+                'prompt': 'Hi there'
+            },
+            {
+                'role': 'HUMAN',
+                'prompt': 'How are you?'
+            },
+        ])
+
+        results = model.generate([prompt_list], max_out_len=100)
+
+        self.assertEqual(len(results), 1)
+        call_args = mock_requests.request.call_args
+        sent_data = call_args[1]['json']
+        messages = sent_data['messages']
+        self.assertEqual(messages[0]['role'], 'user')
+        self.assertEqual(messages[1]['role'], 'assistant')
+        self.assertEqual(messages[2]['role'], 'user')
+
+    @patch('opencompass.models.minimax_api.requests')
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_generate_rate_limit_retry(self, mock_requests):
+        """Test retry on rate limit (base_resp status_code 1002)."""
+        rate_limited = MagicMock()
+        rate_limited.status_code = 200
+        rate_limited.json.return_value = {
+            'base_resp': {
+                'status_code': 1002,
+                'status_msg': 'rate limit'
+            }
+        }
+
+        success = MagicMock()
+        success.status_code = 200
+        success.json.return_value = {
+            'choices': [{
+                'message': {
+                    'content': 'Success after retry'
+                }
+            }]
+        }
+
+        mock_requests.request.side_effect = [rate_limited, success]
+
+        model = MiniMaxAPI(path='MiniMax-M2.7', retry=3)
+        results = model.generate(['Hello'], max_out_len=100)
+
+        self.assertEqual(results[0], 'Success after retry')
+
+    @patch('opencompass.models.minimax_api.requests')
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_generate_http_429_retry(self, mock_requests):
+        """Test retry on HTTP 429 rate limit."""
+        rate_limited = MagicMock()
+        rate_limited.status_code = 429
+        rate_limited.json.return_value = {'error': 'rate limit'}
+
+        success = MagicMock()
+        success.status_code = 200
+        success.json.return_value = {
+            'choices': [{
+                'message': {
+                    'content': 'Success'
+                }
+            }]
+        }
+
+        mock_requests.request.side_effect = [rate_limited, success]
+
+        model = MiniMaxAPI(path='MiniMax-M2.7', retry=3)
+        results = model.generate(['Hello'], max_out_len=100)
+
+        self.assertEqual(results[0], 'Success')
+
+    @patch('opencompass.models.minimax_api.requests')
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_generate_all_retries_exhausted(self, mock_requests):
+        """Test RuntimeError when all retries are exhausted."""
+        fail = MagicMock()
+        fail.status_code = 500
+        fail.json.return_value = {'error': 'server error'}
+
+        mock_requests.request.return_value = fail
+
+        model = MiniMaxAPI(path='MiniMax-M2.7', retry=2)
+
+        with self.assertRaises(RuntimeError):
+            model.generate(['Hello'], max_out_len=100)
+
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_api_base_url(self):
+        """Test that the default API base URL is correct."""
+        self.assertEqual(MINIMAX_API_BASE,
+                         'https://api.minimax.io/v1/chat/completions')
+
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
+    def test_think_tag_default(self):
+        """Test default think_tag is </think>."""
+        model = MiniMaxAPI(path='MiniMax-M2.7')
+        self.assertEqual(model.think_tag, '</think>')
+
+
+class TestMiniMaxChatCompletionV2(unittest.TestCase):
+    """Test cases for MiniMaxChatCompletionV2 (backward compatibility)."""
+
+    def test_initialization(self):
+        """Test basic initialization."""
+        model = MiniMaxChatCompletionV2(
+            path='MiniMax-M2.5',
+            key='test-key',
+        )
+
+        self.assertEqual(model.model, 'MiniMax-M2.5')
+        self.assertEqual(model.url, MINIMAX_API_BASE)
+
+    def test_initialization_with_custom_url(self):
+        """Test initialization with custom URL."""
+        model = MiniMaxChatCompletionV2(
+            path='abab5.5-chat',
+            key='test-key',
+            url='https://api.minimax.chat/v1/text/chatcompletion_v2',
+        )
+
+        self.assertEqual(
+            model.url,
+            'https://api.minimax.chat/v1/text/chatcompletion_v2')
+
+    @patch('opencompass.models.minimax_api.requests')
+    def test_generate_basic(self, mock_requests):
+        """Test basic generate with MiniMaxChatCompletionV2."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'choices': [{
+                'message': {
+                    'content': 'Hello from MiniMax'
+                }
+            }]
+        }
+        mock_requests.request.return_value = mock_response
+
+        model = MiniMaxChatCompletionV2(
+            path='MiniMax-M2.5',
+            key='test-key',
+        )
+        results = model.generate(['Hi'], max_out_len=100)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0], 'Hello from MiniMax')
+
+
+class TestMiniMaxAPIIntegration(unittest.TestCase):
+    """Integration tests for MiniMaxAPI (require MINIMAX_API_KEY)."""
+
+    @unittest.skipUnless(
+        __import__('os').environ.get('MINIMAX_API_KEY'),
+        'MINIMAX_API_KEY not set')
+    def test_real_api_call(self):
+        """Test a real API call to MiniMax."""
+        model = MiniMaxAPI(
+            path='MiniMax-M2.7',
+            key='ENV',
+            retry=2,
+        )
+
+        results = model.generate(['Say hello'],
+                                 max_out_len=200)
+        self.assertEqual(len(results), 1)
+        self.assertTrue(
+            'hello' in results[0].lower() or 'hi' in results[0].lower())
+
+    @unittest.skipUnless(
+        __import__('os').environ.get('MINIMAX_API_KEY'),
+        'MINIMAX_API_KEY not set')
+    def test_real_api_m2_5_highspeed(self):
+        """Test a real API call with MiniMax-M2.5-highspeed."""
+        model = MiniMaxAPI(
+            path='MiniMax-M2.5-highspeed',
+            key='ENV',
+            retry=2,
+        )
+
+        # Use higher max_out_len since M2.5-highspeed includes
+        # inline <think>...</think> reasoning tokens
+        results = model.generate(['What is 2+2? Answer with just the number.'],
+                                 max_out_len=500)
+        self.assertEqual(len(results), 1)
+        self.assertIn('4', results[0])
+
+    @unittest.skipUnless(
+        __import__('os').environ.get('MINIMAX_API_KEY'),
+        'MINIMAX_API_KEY not set')
+    def test_real_api_with_temperature(self):
+        """Test a real API call with temperature setting."""
+        model = MiniMaxAPI(
+            path='MiniMax-M2.7',
+            key='ENV',
+            temperature=0.1,
+            retry=2,
+        )
+
+        results = model.generate(
+            ['Capital of France? One word.'],
+            max_out_len=200)
+        self.assertEqual(len(results), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/models/test_minimax_api.py
+++ b/tests/models/test_minimax_api.py
@@ -17,14 +17,14 @@ class TestMiniMaxAPI(unittest.TestCase):
     def test_initialization_basic(self):
         """Test basic initialization with ENV key."""
         model = MiniMaxAPI(
-            path='MiniMax-M2.7',
-            max_seq_len=204800,
+            path='MiniMax-M3',
+            max_seq_len=524288,
             query_per_second=2,
         )
 
-        self.assertEqual(model.path, 'MiniMax-M2.7')
-        self.assertEqual(model.model, 'MiniMax-M2.7')
-        self.assertEqual(model.max_seq_len, 204800)
+        self.assertEqual(model.path, 'MiniMax-M3')
+        self.assertEqual(model.model, 'MiniMax-M3')
+        self.assertEqual(model.max_seq_len, 524288)
         self.assertEqual(model.url, MINIMAX_API_BASE)
         self.assertEqual(model.keys, ['test-key'])
         self.assertIsNone(model.temperature)
@@ -32,7 +32,7 @@ class TestMiniMaxAPI(unittest.TestCase):
     @patch.dict('os.environ', {'MINIMAX_API_KEY': 'key1,key2,key3'})
     def test_initialization_multiple_keys(self):
         """Test initialization with multiple comma-separated keys."""
-        model = MiniMaxAPI(path='MiniMax-M2.7')
+        model = MiniMaxAPI(path='MiniMax-M3')
 
         self.assertEqual(len(model.keys), 3)
         self.assertEqual(model.keys[0], 'key1')
@@ -42,7 +42,7 @@ class TestMiniMaxAPI(unittest.TestCase):
     def test_initialization_with_direct_key(self):
         """Test initialization with a direct API key."""
         model = MiniMaxAPI(
-            path='MiniMax-M2.5',
+            path='MiniMax-M2.7',
             key='my-direct-key',
         )
 
@@ -51,7 +51,7 @@ class TestMiniMaxAPI(unittest.TestCase):
     def test_initialization_with_key_list(self):
         """Test initialization with a list of keys."""
         model = MiniMaxAPI(
-            path='MiniMax-M2.5',
+            path='MiniMax-M2.7',
             key=['key-a', 'key-b'],
         )
 
@@ -63,14 +63,14 @@ class TestMiniMaxAPI(unittest.TestCase):
     def test_initialization_missing_env_key(self):
         """Test that missing MINIMAX_API_KEY raises ValueError."""
         with self.assertRaises(ValueError) as ctx:
-            MiniMaxAPI(path='MiniMax-M2.7', key='ENV')
+            MiniMaxAPI(path='MiniMax-M3', key='ENV')
         self.assertIn('MINIMAX_API_KEY', str(ctx.exception))
 
     @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
     def test_initialization_with_temperature(self):
         """Test initialization with temperature."""
         model = MiniMaxAPI(
-            path='MiniMax-M2.7',
+            path='MiniMax-M3',
             temperature=0.7,
         )
 
@@ -81,7 +81,7 @@ class TestMiniMaxAPI(unittest.TestCase):
         """Test initialization with custom URL."""
         custom_url = 'https://custom.minimax.io/v1/chat/completions'
         model = MiniMaxAPI(
-            path='MiniMax-M2.7',
+            path='MiniMax-M3',
             url=custom_url,
         )
 
@@ -89,16 +89,17 @@ class TestMiniMaxAPI(unittest.TestCase):
 
     @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
     def test_default_model(self):
-        """Test that default model is MiniMax-M2.7."""
+        """Test that default model is MiniMax-M3."""
         model = MiniMaxAPI()
 
-        self.assertEqual(model.model, 'MiniMax-M2.7')
+        self.assertEqual(model.model, 'MiniMax-M3')
+        self.assertEqual(model.max_seq_len, 524288)
 
     @patch.dict('os.environ', {'MINIMAX_API_KEY': 'test-key'})
     def test_key_rotation(self):
         """Test round-robin key rotation."""
         model = MiniMaxAPI(
-            path='MiniMax-M2.7',
+            path='MiniMax-M3',
             key=['key-1', 'key-2', 'key-3'],
         )
 
@@ -465,11 +466,11 @@ class TestMiniMaxChatCompletionV2(unittest.TestCase):
     def test_initialization(self):
         """Test basic initialization."""
         model = MiniMaxChatCompletionV2(
-            path='MiniMax-M2.5',
+            path='MiniMax-M2.7',
             key='test-key',
         )
 
-        self.assertEqual(model.model, 'MiniMax-M2.5')
+        self.assertEqual(model.model, 'MiniMax-M2.7')
         self.assertEqual(model.url, MINIMAX_API_BASE)
 
     def test_initialization_with_custom_url(self):
@@ -499,7 +500,7 @@ class TestMiniMaxChatCompletionV2(unittest.TestCase):
         mock_requests.request.return_value = mock_response
 
         model = MiniMaxChatCompletionV2(
-            path='MiniMax-M2.5',
+            path='MiniMax-M2.7',
             key='test-key',
         )
         results = model.generate(['Hi'], max_out_len=100)
@@ -515,9 +516,9 @@ class TestMiniMaxAPIIntegration(unittest.TestCase):
         __import__('os').environ.get('MINIMAX_API_KEY'),
         'MINIMAX_API_KEY not set')
     def test_real_api_call(self):
-        """Test a real API call to MiniMax."""
+        """Test a real API call to MiniMax-M3 (the default model)."""
         model = MiniMaxAPI(
-            path='MiniMax-M2.7',
+            path='MiniMax-M3',
             key='ENV',
             retry=2,
         )
@@ -531,15 +532,15 @@ class TestMiniMaxAPIIntegration(unittest.TestCase):
     @unittest.skipUnless(
         __import__('os').environ.get('MINIMAX_API_KEY'),
         'MINIMAX_API_KEY not set')
-    def test_real_api_m2_5_highspeed(self):
-        """Test a real API call with MiniMax-M2.5-highspeed."""
+    def test_real_api_m2_7_highspeed(self):
+        """Test a real API call with MiniMax-M2.7-highspeed."""
         model = MiniMaxAPI(
-            path='MiniMax-M2.5-highspeed',
+            path='MiniMax-M2.7-highspeed',
             key='ENV',
             retry=2,
         )
 
-        # Use higher max_out_len since M2.5-highspeed includes
+        # Use higher max_out_len since highspeed models may include
         # inline <think>...</think> reasoning tokens
         results = model.generate(['What is 2+2? Answer with just the number.'],
                                  max_out_len=500)
@@ -552,7 +553,7 @@ class TestMiniMaxAPIIntegration(unittest.TestCase):
     def test_real_api_with_temperature(self):
         """Test a real API call with temperature setting."""
         model = MiniMaxAPI(
-            path='MiniMax-M2.7',
+            path='MiniMax-M3',
             key='ENV',
             temperature=0.1,
             retry=2,


### PR DESCRIPTION
## Summary

Upgrade the MiniMax LLM provider integration to use the latest **MiniMax-M3** as the default model. MiniMax-M3 features a 512K context window, up to 128K output, and image input support.

## Changes

- **Add MiniMax-M3** to the model selection list and set as the default for `MiniMaxAPI`
- **Keep** `MiniMax-M2.7` and add `MiniMax-M2.7-highspeed` as alternatives
- **Remove** older models (`MiniMax-M2.5`, `MiniMax-M2.5-highspeed`)
- Update related unit tests and integration tests

## Model Lineup (after this PR)

| Model | Context | Notes |
|-------|---------|-------|
| `MiniMax-M3` | 512K | **Default**, supports image input |
| `MiniMax-M2.7` | 204K | Previous generation |
| `MiniMax-M2.7-highspeed` | 204K | Previous generation, low-latency variant |

## File Changes

| File | Change |
|------|--------|
| `opencompass/models/minimax_api.py` | `MiniMaxAPI` default `path` → `MiniMax-M3`, default `max_seq_len` → 524288 |
| `opencompass/configs/models/minimax/minimax_m3.py` | **New** — M3 config (default) |
| `opencompass/configs/models/minimax/minimax_m2_7_highspeed.py` | **New** — M2.7-highspeed config |
| `opencompass/configs/models/minimax/minimax_m2_5.py` | **Removed** |
| `opencompass/configs/models/minimax/minimax_m2_5_highspeed.py` | **Removed** |
| `tests/models/test_minimax_api.py` | Update tests for new default and lineup |

## Usage

```python
from opencompass.models import MiniMaxAPI

# Uses MiniMax-M3 by default (512K context)
model = MiniMaxAPI(key="ENV")  # reads from MINIMAX_API_KEY

# Or specify explicitly
model_m27 = MiniMaxAPI(path="MiniMax-M2.7", key="ENV")

results = model.generate(["What is 2+2?"], max_out_len=500)
```

## Test plan

- [x] Unit tests updated for M3 as default model
- [x] Integration tests updated (`test_real_api_call` uses M3, `test_real_api_m2_7_highspeed` validates highspeed variant)
- [x] Backward compatibility tests retained for `MiniMaxChatCompletionV2`