### PR TITLE
[Fix] Use pre-tokenized prompts in VLLMwithChatTemplate to avoid modifying model input

### DIFF
--- a/opencompass/models/vllm_with_tf_above_v4_33.py
+++ b/opencompass/models/vllm_with_tf_above_v4_33.py
@@ -124,14 +124,18 @@ class VLLMwithChatTemplate(BaseModel):
         if self.fastchat_template:
             messages = _format_with_fast_chat_template(messages, self.fastchat_template)
         else:
-            messages = [self.tokenizer.apply_chat_template(m, add_generation_prompt=True, tokenize=False, **self.chat_template_kwargs) for m in messages]
-            # vLLM tokenize prompts by AutoTokenizer with its default parameter "add_special_token=True"
-            # OC add bos_token in the prompt, which requires tokenizing prompts using "add_speicial_token=False"
-            # But vLLM doesn't have "add_speicial_token" in the pipeline API. So, we remove bos_token
-            # from messages as a workaround
-            if self.tokenizer.bos_token:
-                bos_token = self.tokenizer.bos_token
-                messages = [message.removeprefix(bos_token) if message.startswith(bos_token) else message for message in messages]
+            # Use tokenize=True to get token IDs directly from
+            # apply_chat_template, then pass them as pre-tokenized prompts
+            # to vLLM. This avoids vLLM re-tokenizing the text with
+            # add_special_tokens=True, which would duplicate special tokens
+            # (e.g. BOS) that the chat template already includes.
+            messages = [
+                {"prompt_token_ids": self.tokenizer.apply_chat_template(
+                    m, add_generation_prompt=True, tokenize=True,
+                    **self.chat_template_kwargs
+                )}
+                for m in messages
+            ]
         DEFAULT_GENERATION_KWARGS = {
             'temperature': 0,
             'max_tokens': max_out_len,


### PR DESCRIPTION
## Summary

`VLLMwithChatTemplate.generate()` currently calls `apply_chat_template(tokenize=False)` to produce text, then manually strips the BOS token as a workaround for vLLM re-adding it during tokenization (`add_special_tokens=True`). This approach silently modifies the model's intended input sequence and can cause incorrect evaluation results for models whose chat templates deliberately include BOS.

This PR fixes the issue by:
- Using `apply_chat_template(tokenize=True)` to obtain token IDs directly
- Passing them as pre-tokenized prompts (`{"prompt_token_ids": ...}`) to vLLM

This preserves the exact token sequence the chat template produces, without any manual modification, and avoids the double-BOS problem entirely.

## Motivation

The previous workaround (lines 128-134) had several issues:
1. **Modifies model input** — stripping BOS changes the token sequence the model was designed to receive
2. **Fragile** — only handles text-level BOS prefix; fails if the tokenizer represents BOS differently
3. **Unnecessary** — vLLM natively supports `prompt_token_ids`, which bypasses its internal tokenization entirely

## Test plan

- [x] Verified the fix preserves the same token IDs that `apply_chat_template` produces (no extra/missing BOS)
- [ ] Run evaluation with a model that has BOS in its chat template (e.g., LLaMA-based) and confirm results match expectations

Made with [Cursor](https://cursor.com)