### PR TITLE
feat: add LiteLLM as AI gateway model backend

### DIFF
--- a/docs/en/user_guides/models.md
+++ b/docs/en/user_guides/models.md
@@ -70,6 +70,7 @@ model = HuggingFaceCausalLM(
 Currently, OpenCompass supports API-based model inference for the following:
 
 - OpenAI (`opencompass.models.OpenAI`)
+- LiteLLM - unified gateway to 100+ providers (`opencompass.models.LiteLLMAPI`)
 - ChatGLM (`opencompass.models.ZhiPuAI`)
 - ABAB-Chat from MiniMax (`opencompass.models.MiniMax`)
 - XunFei from XunFei (`opencompass.models.XunFei`)

--- a/docs/zh_cn/user_guides/models.md
+++ b/docs/zh_cn/user_guides/models.md
@@ -63,6 +63,7 @@ model = HuggingFaceCausalLM(
 OpenCompass 目前支持以下基于 API 的模型推理：
 
 - OpenAI（`opencompass.models.OpenAI`）
+- LiteLLM - 100+ 供应商统一网关 (`opencompass.models.LiteLLMAPI`)
 - ChatGLM@智谱清言 (`opencompass.models.ZhiPuAI`)
 - ABAB-Chat@MiniMax (`opencompass.models.MiniMax`)
 - XunFei@科大讯飞 (`opencompass.models.XunFei`)

--- a/opencompass/models/__init__.py
+++ b/opencompass/models/__init__.py
@@ -25,6 +25,7 @@ from .intern_model import InternLM  # noqa: F401
 from .interntrain import InternTrain  # noqa: F401
 from .krgpt_api import KrGPT  # noqa: F401
 from .lightllm_api import LightllmAPI, LightllmChatAPI  # noqa: F401
+from .litellm_api import LiteLLMAPI  # noqa: F401
 from .llama2 import Llama2, Llama2Chat  # noqa: F401
 from .minimax_api import MiniMax, MiniMaxChatCompletionV2  # noqa: F401
 from .mistral_api import Mistral  # noqa: F401

--- a/opencompass/models/litellm_api.py
+++ b/opencompass/models/litellm_api.py
@@ -174,9 +174,11 @@ class LiteLLMAPI(BaseAPIModel):
     def _build_call_kwargs(self, messages: List[Dict[str, str]],
                            max_out_len: int) -> Dict:
         call_kwargs: Dict = {
+            **self.extra_body,
             'model': self.path,
             'messages': messages,
             'max_tokens': max_out_len,
+            'drop_params': True,
         }
         if self.temperature is not None:
             call_kwargs['temperature'] = self.temperature
@@ -186,7 +188,6 @@ class LiteLLMAPI(BaseAPIModel):
             call_kwargs['api_base'] = self.api_base
         if self.api_version is not None:
             call_kwargs['api_version'] = self.api_version
-        call_kwargs.update(self.extra_body)
         return call_kwargs
 
     def _generate(self, input: PromptType, max_out_len: int) -> str:

--- a/opencompass/models/litellm_api.py
+++ b/opencompass/models/litellm_api.py
@@ -1,0 +1,235 @@
+"""LiteLLM AI gateway backend for OpenCompass.
+
+Routes ``generate`` through ``litellm.completion()`` to 100+ providers (OpenAI,
+Anthropic, Bedrock, Azure, Vertex, Gemini, Ollama, OpenRouter, Groq, DeepSeek,
+etc.) using provider-native API keys. The target model is selected by its
+LiteLLM-style prefix, e.g. ``anthropic/claude-3-5-sonnet-20241022``,
+``azure/gpt-4o``, ``bedrock/anthropic.claude-3-sonnet-20240229-v1:0``,
+``ollama/llama3``.
+
+See https://docs.litellm.ai/docs/providers for the full list of supported
+providers and their model-name prefix convention.
+"""
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Dict, List, Optional, Union
+
+from opencompass.registry import MODELS
+from opencompass.utils.prompt import PromptList
+
+from .base_api import BaseAPIModel
+
+PromptType = Union[PromptList, str]
+
+CHATML_ROLE = ['system', 'user', 'assistant']
+
+
+@MODELS.register_module()
+class LiteLLMAPI(BaseAPIModel):
+    """Model wrapper that dispatches to ``litellm.completion``.
+
+    Args:
+        path (str): LiteLLM-style fully-qualified model name, e.g.
+            ``anthropic/claude-3-5-sonnet-20241022`` or ``azure/gpt-4o``.
+            Forwarded directly as ``litellm.completion(model=...)``.
+        key (str, optional): Provider API key. When ``None`` (default), LiteLLM
+            resolves credentials from provider-specific env vars
+            (``OPENAI_API_KEY``, ``ANTHROPIC_API_KEY``, ``GEMINI_API_KEY``,
+            ``AWS_*``, ``GROQ_API_KEY``, ...) based on the model prefix.
+        api_base (str, optional): Custom base URL. Forwarded as LiteLLM's
+            ``api_base`` kwarg. Useful for self-hosted endpoints, proxies,
+            and Azure deployments.
+        api_version (str, optional): For Azure OpenAI deployments (e.g.
+            ``2025-01-01-preview``). Forwarded as LiteLLM's ``api_version``.
+        query_per_second (int): Max queries per second. Defaults to 2.
+        rpm_verbose (bool): Whether to log throttling. Defaults to False.
+        max_seq_len (int): Max sequence length (used by the BaseAPIModel
+            plumbing for length bookkeeping). Defaults to 16384.
+        meta_template (Dict, optional): Standard OpenCompass meta template.
+        retry (int): Retries on transient failure. Defaults to 2.
+        system_prompt (str): Optional system message prepended to every
+            request when no system message is already present. Defaults to ``''``.
+        temperature (float, optional): Sampling temperature. If unset, LiteLLM
+            uses the per-provider default.
+        max_workers (int, optional): Size of the ThreadPoolExecutor for batch
+            dispatch. Defaults to ``None`` (Python default).
+        extra_body (Dict, optional): Arbitrary extra kwargs forwarded to
+            ``litellm.completion``, e.g. ``{"reasoning_effort": "high"}``.
+    """
+
+    is_api: bool = True
+
+    def __init__(
+        self,
+        path: str,
+        key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        api_version: Optional[str] = None,
+        query_per_second: int = 2,
+        rpm_verbose: bool = False,
+        max_seq_len: int = 16384,
+        meta_template: Optional[Dict] = None,
+        retry: int = 2,
+        system_prompt: str = '',
+        temperature: Optional[float] = None,
+        max_workers: Optional[int] = None,
+        extra_body: Optional[Dict] = None,
+    ):
+        super().__init__(
+            path=path,
+            max_seq_len=max_seq_len,
+            query_per_second=query_per_second,
+            rpm_verbose=rpm_verbose,
+            meta_template=meta_template,
+            retry=retry,
+        )
+        self.key = key
+        self.api_base = api_base
+        self.api_version = api_version
+        self.system_prompt = system_prompt
+        self.temperature = temperature
+        self.max_workers = max_workers
+        self.extra_body = extra_body or {}
+
+    def generate(
+        self,
+        inputs: List[PromptType],
+        max_out_len: int = 512,
+        **gen_kwargs,
+    ) -> List[str]:
+        """Generate responses for a batch of inputs.
+
+        Args:
+            inputs: list of strings or ``PromptList`` messages.
+            max_out_len: max output tokens per response. Defaults to 512.
+            **gen_kwargs: currently accepted for API compatibility with the
+                base class; no additional kwargs are forwarded to LiteLLM
+                beyond what ``__init__`` configured.
+
+        Returns:
+            list of generated strings, one per input.
+        """
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            results = list(
+                executor.map(self._generate, inputs,
+                             [max_out_len] * len(inputs)))
+        self.flush()
+        return results
+
+    def _build_messages(self, input: PromptType) -> List[Dict[str, str]]:
+        """Convert an OpenCompass input into an OpenAI-shaped ``messages`` list.
+
+        Handles three cases:
+            1. plain ``str`` -> wrap as a single ``user`` message.
+            2. ``PromptList`` of CHATML-shaped dicts (role in
+               {'system','user','assistant'}, key ``'content'``) -> pass through.
+            3. ``PromptList`` of OpenCompass-native dicts (role in
+               {'SYSTEM','HUMAN','BOT'}, key ``'prompt'``) -> translate roles
+               to OpenAI convention and rename the content key.
+
+        Prepends ``self.system_prompt`` as a system message iff no system
+        message is already present in the result.
+        """
+        if isinstance(input, str):
+            messages = [{'role': 'user', 'content': input}]
+        elif (isinstance(input, list) and len(input) > 0
+              and all(isinstance(item, dict) and 'role' in item
+                      and item['role'] in CHATML_ROLE for item in input)):
+            # Already CHATML-shaped, assume ``content`` key is populated.
+            messages = [{
+                'role': item['role'],
+                'content': item.get('content', item.get('prompt', '')),
+            } for item in input]
+        else:
+            messages = []
+            assert isinstance(input, PromptList), (
+                'Expected str or PromptList, got '
+                f'{type(input).__name__}: {input!r}')
+            for item in input:
+                if isinstance(item, str):
+                    messages.append({'role': 'user', 'content': item})
+                    continue
+                role = item.get('role', '')
+                content = item.get('prompt', item.get('content', ''))
+                if role == 'HUMAN':
+                    messages.append({'role': 'user', 'content': content})
+                elif role == 'BOT':
+                    messages.append({'role': 'assistant', 'content': content})
+                elif role == 'SYSTEM':
+                    messages.append({'role': 'system', 'content': content})
+                else:
+                    # Unknown role — default to user to avoid losing content.
+                    messages.append({'role': 'user', 'content': content})
+
+        if self.system_prompt and not any(m['role'] == 'system'
+                                          for m in messages):
+            messages.insert(0, {
+                'role': 'system',
+                'content': self.system_prompt,
+            })
+
+        return messages
+
+    def _build_call_kwargs(self, messages: List[Dict[str, str]],
+                           max_out_len: int) -> Dict:
+        call_kwargs: Dict = {
+            'model': self.path,
+            'messages': messages,
+            'max_tokens': max_out_len,
+        }
+        if self.temperature is not None:
+            call_kwargs['temperature'] = self.temperature
+        if self.key is not None:
+            call_kwargs['api_key'] = self.key
+        if self.api_base is not None:
+            call_kwargs['api_base'] = self.api_base
+        if self.api_version is not None:
+            call_kwargs['api_version'] = self.api_version
+        call_kwargs.update(self.extra_body)
+        return call_kwargs
+
+    def _generate(self, input: PromptType, max_out_len: int) -> str:
+        try:
+            import litellm
+        except ImportError as err:
+            raise ImportError(
+                'litellm is not installed. Install with: '
+                'pip install litellm') from err
+
+        assert isinstance(input, (str, PromptList))
+
+        messages = self._build_messages(input)
+        call_kwargs = self._build_call_kwargs(messages, max_out_len)
+
+        num_retries = 0
+        last_err: Optional[BaseException] = None
+        while num_retries < self.retry:
+            self.acquire()
+            try:
+                response = litellm.completion(**call_kwargs)
+            except Exception as err:  # noqa: BLE001
+                last_err = err
+                num_retries += 1
+                self.logger.warning(
+                    f'LiteLLM request failed '
+                    f'(attempt {num_retries}/{self.retry}): {err}')
+                time.sleep(1)
+                continue
+            finally:
+                self.release()
+
+            try:
+                content = response.choices[0].message.content
+                # Some providers return ``None`` on filtered / empty output.
+                return content or ''
+            except (AttributeError, IndexError, TypeError) as err:
+                last_err = err
+                num_retries += 1
+                self.logger.warning(
+                    f'LiteLLM response parse failed '
+                    f'(attempt {num_retries}/{self.retry}): {err}')
+                time.sleep(1)
+
+        raise RuntimeError(
+            f'LiteLLM request failed after {self.retry} retries: {last_err}')

--- a/opencompass/models/litellm_api.py
+++ b/opencompass/models/litellm_api.py
@@ -13,16 +13,18 @@ providers and their model-name prefix convention.
 
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from opencompass.registry import MODELS
 from opencompass.utils.prompt import PromptList
 
 from .base_api import BaseAPIModel
 
-PromptType = Union[PromptList, str]
+PromptType = Union[PromptList, List, str]
 
 CHATML_ROLE = ['system', 'user', 'assistant']
+CORE_CALL_KWARGS = {'model', 'messages', 'max_tokens', 'drop_params', 'stream'}
+RESERVED_OUTPUT_TOKENS = 100
 
 
 @MODELS.register_module()
@@ -48,10 +50,15 @@ class LiteLLMAPI(BaseAPIModel):
             plumbing for length bookkeeping). Defaults to 16384.
         meta_template (Dict, optional): Standard OpenCompass meta template.
         retry (int): Retries on transient failure. Defaults to 2.
-        system_prompt (str): Optional system message prepended to every
-            request when no system message is already present. Defaults to ``''``.
+        system_prompt (str): Optional system message prepended when no
+            system message is already present. Defaults to ``''``.
         temperature (float, optional): Sampling temperature. If unset, LiteLLM
             uses the per-provider default.
+        stream (bool): Whether to request streaming responses from LiteLLM.
+            Defaults to False.
+        think_tag (str): Tag inserted between reasoning content and final
+            answer when LiteLLM returns ``reasoning_content``. Defaults to
+            ``'</think>'``.
         max_workers (int, optional): Size of the ThreadPoolExecutor for batch
             dispatch. Defaults to ``None`` (Python default).
         extra_body (Dict, optional): Arbitrary extra kwargs forwarded to
@@ -73,6 +80,8 @@ class LiteLLMAPI(BaseAPIModel):
         retry: int = 2,
         system_prompt: str = '',
         temperature: Optional[float] = None,
+        stream: bool = False,
+        think_tag: str = '</think>',
         max_workers: Optional[int] = None,
         extra_body: Optional[Dict] = None,
     ):
@@ -89,6 +98,8 @@ class LiteLLMAPI(BaseAPIModel):
         self.api_version = api_version
         self.system_prompt = system_prompt
         self.temperature = temperature
+        self.stream = stream
+        self.think_tag = think_tag
         self.max_workers = max_workers
         self.extra_body = extra_body or {}
 
@@ -103,9 +114,8 @@ class LiteLLMAPI(BaseAPIModel):
         Args:
             inputs: list of strings or ``PromptList`` messages.
             max_out_len: max output tokens per response. Defaults to 512.
-            **gen_kwargs: currently accepted for API compatibility with the
-                base class; no additional kwargs are forwarded to LiteLLM
-                beyond what ``__init__`` configured.
+            **gen_kwargs: extra per-call generation kwargs forwarded to
+                LiteLLM, except core request fields managed by this wrapper.
 
         Returns:
             list of generated strings, one per input.
@@ -113,17 +123,18 @@ class LiteLLMAPI(BaseAPIModel):
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             results = list(
                 executor.map(self._generate, inputs,
-                             [max_out_len] * len(inputs)))
+                             [max_out_len] * len(inputs),
+                             [gen_kwargs] * len(inputs)))
         self.flush()
         return results
 
     def _build_messages(self, input: PromptType) -> List[Dict[str, str]]:
-        """Convert an OpenCompass input into an OpenAI-shaped ``messages`` list.
+        """Convert an OpenCompass input into OpenAI-shaped messages.
 
         Handles three cases:
             1. plain ``str`` -> wrap as a single ``user`` message.
             2. ``PromptList`` of CHATML-shaped dicts (role in
-               {'system','user','assistant'}, key ``'content'``) -> pass through.
+               CHATML_ROLE, key ``'content'``) -> pass through.
             3. ``PromptList`` of OpenCompass-native dicts (role in
                {'SYSTEM','HUMAN','BOT'}, key ``'prompt'``) -> translate roles
                to OpenAI convention and rename the content key.
@@ -133,9 +144,9 @@ class LiteLLMAPI(BaseAPIModel):
         """
         if isinstance(input, str):
             messages = [{'role': 'user', 'content': input}]
-        elif (isinstance(input, list) and len(input) > 0
-              and all(isinstance(item, dict) and 'role' in item
-                      and item['role'] in CHATML_ROLE for item in input)):
+        elif (isinstance(input, list) and len(input) > 0 and all(
+                isinstance(item, dict) and 'role' in item
+                and item['role'] in CHATML_ROLE for item in input)):
             # Already CHATML-shaped, assume ``content`` key is populated.
             messages = [{
                 'role': item['role'],
@@ -143,9 +154,9 @@ class LiteLLMAPI(BaseAPIModel):
             } for item in input]
         else:
             messages = []
-            assert isinstance(input, PromptList), (
-                'Expected str or PromptList, got '
-                f'{type(input).__name__}: {input!r}')
+            assert isinstance(input,
+                              list), ('Expected str or list-like prompt, got '
+                                      f'{type(input).__name__}: {input!r}')
             for item in input:
                 if isinstance(item, str):
                     messages.append({'role': 'user', 'content': item})
@@ -171,10 +182,58 @@ class LiteLLMAPI(BaseAPIModel):
 
         return messages
 
-    def _build_call_kwargs(self, messages: List[Dict[str, str]],
-                           max_out_len: int) -> Dict:
+    def _get_messages_token_len(self, messages: List[Dict[str, str]]) -> int:
+        return sum(
+            self.get_token_len(str(message.get('content', '')))
+            for message in messages)
+
+    def _adjust_max_out_len(self, messages: List[Dict[str, str]],
+                            max_out_len: int) -> int:
+        input_len = self._get_messages_token_len(messages)
+        if input_len > self.max_seq_len:
+            raise ValueError(
+                f'Input length ({input_len}) exceeds max_seq_len '
+                f'({self.max_seq_len}). Please increase max_seq_len or '
+                'shorten the prompt.')
+
+        available_out_len = (self.max_seq_len - input_len -
+                             RESERVED_OUTPUT_TOKENS)
+        if available_out_len <= 0:
+            raise ValueError(
+                f'max_out_len ({available_out_len}) is less than or equal '
+                f'to 0. This may be due to input length ({input_len}) being '
+                f'too close to max_seq_len ({self.max_seq_len}). Please '
+                'increase max_seq_len or shorten the prompt.')
+
+        adjusted_max_out_len = min(max_out_len, available_out_len)
+        if adjusted_max_out_len < max_out_len:
+            self.logger.warning(
+                f'max_out_len was truncated from {max_out_len} to '
+                f'{adjusted_max_out_len} due to input length')
+        return adjusted_max_out_len
+
+    def _build_call_kwargs(self,
+                           messages: List[Dict[str, str]],
+                           max_out_len: int,
+                           gen_kwargs: Optional[Dict] = None) -> Dict:
+        gen_kwargs = gen_kwargs or {}
+        blocked_kwargs = sorted(set(gen_kwargs) & CORE_CALL_KWARGS)
+        if blocked_kwargs:
+            self.logger.warning(
+                'Ignoring LiteLLM generation kwargs that would override '
+                f'core request fields: {blocked_kwargs}')
+        safe_gen_kwargs = {
+            key: value
+            for key, value in gen_kwargs.items() if key not in CORE_CALL_KWARGS
+        }
+        safe_extra_body = {
+            key: value
+            for key, value in self.extra_body.items()
+            if key not in CORE_CALL_KWARGS
+        }
         call_kwargs: Dict = {
-            **self.extra_body,
+            **safe_extra_body,
+            **safe_gen_kwargs,
             'model': self.path,
             'messages': messages,
             'max_tokens': max_out_len,
@@ -188,20 +247,75 @@ class LiteLLMAPI(BaseAPIModel):
             call_kwargs['api_base'] = self.api_base
         if self.api_version is not None:
             call_kwargs['api_version'] = self.api_version
+        if self.stream:
+            call_kwargs['stream'] = True
         return call_kwargs
 
-    def _generate(self, input: PromptType, max_out_len: int) -> str:
+    @staticmethod
+    def _get_field(obj: Any, field: str):
+        if isinstance(obj, dict):
+            return obj.get(field)
+        return getattr(obj, field, None)
+
+    def _get_reasoning_content(self, message: Any) -> str:
+        reasoning_content = self._get_field(message, 'reasoning_content')
+        if reasoning_content:
+            return reasoning_content
+
+        thinking_blocks = self._get_field(message, 'thinking_blocks') or []
+        chunks: List[str] = []
+        for block in thinking_blocks:
+            block_type = self._get_field(block, 'type')
+            if block_type and block_type != 'thinking':
+                continue
+            thinking = self._get_field(block, 'thinking')
+            if thinking:
+                chunks.append(thinking)
+        return ''.join(chunks)
+
+    def _merge_reasoning_content(self, content: Optional[str],
+                                 reasoning_content: Optional[str]) -> str:
+        content = content or ''
+        reasoning_content = reasoning_content or ''
+        if not reasoning_content:
+            return content
+        if content:
+            return reasoning_content + self.think_tag + content
+        return reasoning_content
+
+    def _parse_stream_response(self, response) -> str:
+        content_chunks: List[str] = []
+        reasoning_chunks: List[str] = []
+        for chunk in response:
+            choices = self._get_field(chunk, 'choices') or []
+            if not choices:
+                continue
+            delta = self._get_field(choices[0], 'delta')
+            reasoning_content = self._get_field(delta, 'reasoning_content')
+            if reasoning_content:
+                reasoning_chunks.append(reasoning_content)
+            content = self._get_field(delta, 'content')
+            if content:
+                content_chunks.append(content)
+        return self._merge_reasoning_content(''.join(content_chunks),
+                                             ''.join(reasoning_chunks))
+
+    def _generate(self,
+                  input: PromptType,
+                  max_out_len: int,
+                  gen_kwargs: Optional[Dict] = None) -> str:
         try:
             import litellm
         except ImportError as err:
-            raise ImportError(
-                'litellm is not installed. Install with: '
-                'pip install litellm') from err
+            raise ImportError('litellm is not installed. Install with: '
+                              'pip install litellm') from err
 
-        assert isinstance(input, (str, PromptList))
+        assert isinstance(input, (str, list))
 
         messages = self._build_messages(input)
-        call_kwargs = self._build_call_kwargs(messages, max_out_len)
+        max_out_len = self._adjust_max_out_len(messages, max_out_len)
+        call_kwargs = self._build_call_kwargs(messages, max_out_len,
+                                              gen_kwargs)
 
         num_retries = 0
         last_err: Optional[BaseException] = None
@@ -209,6 +323,8 @@ class LiteLLMAPI(BaseAPIModel):
             self.acquire()
             try:
                 response = litellm.completion(**call_kwargs)
+                if self.stream:
+                    return self._parse_stream_response(response)
             except Exception as err:  # noqa: BLE001
                 last_err = err
                 num_retries += 1
@@ -221,9 +337,12 @@ class LiteLLMAPI(BaseAPIModel):
                 self.release()
 
             try:
-                content = response.choices[0].message.content
+                message = response.choices[0].message
+                content = self._get_field(message, 'content')
+                reasoning_content = self._get_reasoning_content(message)
                 # Some providers return ``None`` on filtered / empty output.
-                return content or ''
+                return self._merge_reasoning_content(content,
+                                                     reasoning_content)
             except (AttributeError, IndexError, TypeError) as err:
                 last_err = err
                 num_retries += 1

--- a/requirements/api.txt
+++ b/requirements/api.txt
@@ -7,6 +7,8 @@ openai
  # xunfei
 spark_ai_python
 sseclient-py==1.7.2
+# LiteLLM AI gateway (routes to 100+ providers via litellm.completion)
+litellm
 # tecent
 tencentcloud-sdk-python
 # bytedance

--- a/requirements/api.txt
+++ b/requirements/api.txt
@@ -8,7 +8,7 @@ openai
 spark_ai_python
 sseclient-py==1.7.2
 # LiteLLM AI gateway (routes to 100+ providers via litellm.completion)
-litellm
+litellm>=1.55,<1.85
 # tecent
 tencentcloud-sdk-python
 # bytedance

--- a/requirements/api.txt
+++ b/requirements/api.txt
@@ -7,8 +7,6 @@ openai
  # xunfei
 spark_ai_python
 sseclient-py==1.7.2
-# LiteLLM AI gateway (routes to 100+ providers via litellm.completion)
-litellm>=1.55,<1.85
 # tecent
 tencentcloud-sdk-python
 # bytedance

--- a/tests/models/test_litellm_api.py
+++ b/tests/models/test_litellm_api.py
@@ -81,6 +81,27 @@ class TestLiteLLMAPIInit(unittest.TestCase):
         self.assertNotIn('api_version', kwargs)
         self.assertNotIn('temperature', kwargs)
 
+    def test_drop_params_default_true(self):
+        model = LiteLLMAPI(path='openai/gpt-4o-mini')
+        kwargs = model._build_call_kwargs(
+            messages=[{'role': 'user', 'content': 'hi'}],
+            max_out_len=128,
+        )
+        self.assertTrue(kwargs['drop_params'])
+
+    def test_extra_body_cannot_override_core_params(self):
+        """extra_body should not override model, messages, or max_tokens."""
+        model = LiteLLMAPI(
+            path='openai/gpt-4o-mini',
+            extra_body={'model': 'WRONG', 'max_tokens': 999},
+        )
+        kwargs = model._build_call_kwargs(
+            messages=[{'role': 'user', 'content': 'hi'}],
+            max_out_len=128,
+        )
+        self.assertEqual(kwargs['model'], 'openai/gpt-4o-mini')
+        self.assertEqual(kwargs['max_tokens'], 128)
+
 
 class TestLiteLLMAPIMessages(unittest.TestCase):
     """Input-to-OpenAI-messages translation."""

--- a/tests/models/test_litellm_api.py
+++ b/tests/models/test_litellm_api.py
@@ -1,0 +1,287 @@
+"""Unit tests for LiteLLMAPI."""
+
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from opencompass.models.litellm_api import LiteLLMAPI
+from opencompass.utils.prompt import PromptList
+
+
+def _install_litellm_stub():
+    """Register a fake ``litellm`` module so ``import litellm`` resolves.
+
+    Returns the stubbed ``completion`` MagicMock so tests can assert on calls
+    and configure return values / side_effects.
+    """
+    fake = types.ModuleType('litellm')
+    fake.completion = MagicMock(name='litellm.completion')
+    sys.modules['litellm'] = fake
+    return fake.completion
+
+
+def _fake_response(content='hi'):
+    """Build a minimal OpenAI-shaped ``ModelResponse`` stand-in."""
+    message = SimpleNamespace(content=content, role='assistant')
+    choice = SimpleNamespace(message=message, finish_reason='stop', index=0)
+    return SimpleNamespace(choices=[choice], id='cmpl-test', model='test')
+
+
+class TestLiteLLMAPIInit(unittest.TestCase):
+    """Initialization, registration, and kwarg forwarding."""
+
+    def test_registers_in_models_registry(self):
+        from opencompass.registry import MODELS
+
+        cls = MODELS.get('LiteLLMAPI')
+        self.assertIs(cls, LiteLLMAPI)
+
+    def test_default_init_stores_path(self):
+        model = LiteLLMAPI(path='openai/gpt-4o-mini')
+        self.assertEqual(model.path, 'openai/gpt-4o-mini')
+        self.assertEqual(model.retry, 2)
+        self.assertIsNone(model.key)
+        self.assertIsNone(model.api_base)
+        self.assertIsNone(model.api_version)
+
+    def test_call_kwargs_forwards_provider_credentials(self):
+        model = LiteLLMAPI(
+            path='azure/gpt-4o',
+            key='sk-test',
+            api_base='https://example.azure.com',
+            api_version='2025-01-01-preview',
+            temperature=0.1,
+            extra_body={'reasoning_effort': 'high'},
+        )
+        kwargs = model._build_call_kwargs(
+            messages=[{'role': 'user', 'content': 'hi'}],
+            max_out_len=128,
+        )
+        self.assertEqual(kwargs['model'], 'azure/gpt-4o')
+        self.assertEqual(kwargs['api_key'], 'sk-test')
+        self.assertEqual(kwargs['api_base'], 'https://example.azure.com')
+        self.assertEqual(kwargs['api_version'], '2025-01-01-preview')
+        self.assertEqual(kwargs['max_tokens'], 128)
+        self.assertEqual(kwargs['temperature'], 0.1)
+        self.assertEqual(kwargs['reasoning_effort'], 'high')
+
+    def test_call_kwargs_omits_optional_when_blank(self):
+        """When no creds are configured, LiteLLM must be allowed to resolve
+        provider-specific env vars itself — we do not inject ``api_key=None``
+        etc. which would cause 401s."""
+        model = LiteLLMAPI(path='openai/gpt-4o-mini')
+        kwargs = model._build_call_kwargs(
+            messages=[{'role': 'user', 'content': 'hi'}],
+            max_out_len=128,
+        )
+        self.assertNotIn('api_key', kwargs)
+        self.assertNotIn('api_base', kwargs)
+        self.assertNotIn('api_version', kwargs)
+        self.assertNotIn('temperature', kwargs)
+
+
+class TestLiteLLMAPIMessages(unittest.TestCase):
+    """Input-to-OpenAI-messages translation."""
+
+    def test_plain_string_input(self):
+        model = LiteLLMAPI(path='openai/gpt-4o-mini')
+        messages = model._build_messages('hello')
+        self.assertEqual(messages, [{'role': 'user', 'content': 'hello'}])
+
+    def test_opencompass_native_prompt_list(self):
+        """HUMAN/BOT/SYSTEM with 'prompt' key -> user/assistant/system
+        with 'content' key."""
+        model = LiteLLMAPI(path='openai/gpt-4o-mini')
+        prompt_list = PromptList([
+            {
+                'role': 'SYSTEM',
+                'prompt': 'You are helpful.'
+            },
+            {
+                'role': 'HUMAN',
+                'prompt': 'Hi there'
+            },
+            {
+                'role': 'BOT',
+                'prompt': 'Hello!'
+            },
+            {
+                'role': 'HUMAN',
+                'prompt': 'What is 2+2?'
+            },
+        ])
+        messages = model._build_messages(prompt_list)
+        self.assertEqual(messages, [
+            {
+                'role': 'system',
+                'content': 'You are helpful.'
+            },
+            {
+                'role': 'user',
+                'content': 'Hi there'
+            },
+            {
+                'role': 'assistant',
+                'content': 'Hello!'
+            },
+            {
+                'role': 'user',
+                'content': 'What is 2+2?'
+            },
+        ])
+
+    def test_chatml_shaped_prompt_list_passes_through(self):
+        """When upstream has already emitted OpenAI-style CHATML, the message
+        list should be forwarded unchanged (modulo possible system_prompt
+        prepending)."""
+        model = LiteLLMAPI(path='openai/gpt-4o-mini')
+        chatml = [
+            {
+                'role': 'system',
+                'content': 'sys'
+            },
+            {
+                'role': 'user',
+                'content': 'u'
+            },
+        ]
+        messages = model._build_messages(chatml)
+        self.assertEqual(messages, chatml)
+
+    def test_system_prompt_prepended_when_absent(self):
+        model = LiteLLMAPI(path='openai/gpt-4o-mini',
+                           system_prompt='Be concise.')
+        messages = model._build_messages('hi')
+        self.assertEqual(messages[0], {
+            'role': 'system',
+            'content': 'Be concise.'
+        })
+        self.assertEqual(messages[1], {'role': 'user', 'content': 'hi'})
+
+    def test_system_prompt_not_duplicated_when_system_exists(self):
+        """If the caller already supplied a system message, our
+        ``system_prompt`` must not create a second one."""
+        model = LiteLLMAPI(path='openai/gpt-4o-mini',
+                           system_prompt='IGNORE ME')
+        chatml = [
+            {
+                'role': 'system',
+                'content': 'caller-supplied'
+            },
+            {
+                'role': 'user',
+                'content': 'hi'
+            },
+        ]
+        messages = model._build_messages(chatml)
+        system_messages = [m for m in messages if m['role'] == 'system']
+        self.assertEqual(len(system_messages), 1)
+        self.assertEqual(system_messages[0]['content'], 'caller-supplied')
+
+
+class TestLiteLLMAPIGenerate(unittest.TestCase):
+    """End-to-end ``generate`` tests with mocked LiteLLM."""
+
+    def test_generate_single_string(self):
+        completion = _install_litellm_stub()
+        completion.return_value = _fake_response('pong')
+
+        model = LiteLLMAPI(path='openai/gpt-4o-mini', key='sk-test')
+        results = model.generate(['ping'], max_out_len=32)
+
+        self.assertEqual(results, ['pong'])
+        completion.assert_called_once()
+        kwargs = completion.call_args.kwargs
+        self.assertEqual(kwargs['model'], 'openai/gpt-4o-mini')
+        self.assertEqual(kwargs['messages'],
+                         [{
+                             'role': 'user',
+                             'content': 'ping'
+                         }])
+        self.assertEqual(kwargs['max_tokens'], 32)
+        self.assertEqual(kwargs['api_key'], 'sk-test')
+
+    def test_generate_preserves_batch_order(self):
+        completion = _install_litellm_stub()
+        completion.side_effect = [
+            _fake_response('a'),
+            _fake_response('b'),
+            _fake_response('c'),
+        ]
+
+        # Force single-worker to keep deterministic order for the side_effect
+        # sequence. (In production order is preserved by ``executor.map``
+        # regardless of workers because we collect with ``list(...)``.)
+        model = LiteLLMAPI(path='openai/gpt-4o-mini', max_workers=1)
+        results = model.generate(['1', '2', '3'])
+
+        self.assertEqual(results, ['a', 'b', 'c'])
+        self.assertEqual(completion.call_count, 3)
+
+    def test_generate_handles_none_content(self):
+        """Some providers return ``message.content = None`` when output is
+        filtered; we must return an empty string rather than raise."""
+        completion = _install_litellm_stub()
+        completion.return_value = _fake_response(content=None)
+
+        model = LiteLLMAPI(path='openai/gpt-4o-mini')
+        results = model.generate(['x'])
+        self.assertEqual(results, [''])
+
+    def test_generate_retries_then_succeeds(self):
+        completion = _install_litellm_stub()
+        completion.side_effect = [
+            Exception('transient'),
+            _fake_response('recovered'),
+        ]
+
+        model = LiteLLMAPI(path='openai/gpt-4o-mini', retry=3)
+        with patch('time.sleep'):  # skip the backoff
+            results = model.generate(['x'])
+        self.assertEqual(results, ['recovered'])
+        self.assertEqual(completion.call_count, 2)
+
+    def test_generate_raises_after_exhausting_retries(self):
+        completion = _install_litellm_stub()
+        completion.side_effect = Exception('permanent')
+
+        model = LiteLLMAPI(path='openai/gpt-4o-mini', retry=2)
+        with patch('time.sleep'):
+            with self.assertRaises(RuntimeError):
+                model.generate(['x'])
+        self.assertEqual(completion.call_count, 2)
+
+    def test_generate_translates_opencompass_native_prompt_list(self):
+        completion = _install_litellm_stub()
+        completion.return_value = _fake_response('4')
+
+        model = LiteLLMAPI(path='openai/gpt-4o-mini')
+        prompt = PromptList([
+            {
+                'role': 'HUMAN',
+                'prompt': 'What is 2+2?'
+            },
+        ])
+        results = model.generate([prompt])
+
+        self.assertEqual(results, ['4'])
+        kwargs = completion.call_args.kwargs
+        self.assertEqual(kwargs['messages'],
+                         [{
+                             'role': 'user',
+                             'content': 'What is 2+2?'
+                         }])
+
+    def test_generate_raises_import_error_without_litellm(self):
+        sys.modules.pop('litellm', None)
+        with patch.dict(sys.modules, {'litellm': None}):
+            model = LiteLLMAPI(path='openai/gpt-4o-mini', retry=1)
+            with self.assertRaises(ImportError) as ctx:
+                model.generate(['hi'])
+            self.assertIn('pip install litellm', str(ctx.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/models/test_litellm_api.py
+++ b/tests/models/test_litellm_api.py
@@ -22,11 +22,25 @@ def _install_litellm_stub():
     return fake.completion
 
 
-def _fake_response(content='hi'):
+def _fake_response(content='hi', reasoning_content=None,
+                   thinking_blocks=None):
     """Build a minimal OpenAI-shaped ``ModelResponse`` stand-in."""
     message = SimpleNamespace(content=content, role='assistant')
+    if reasoning_content is not None:
+        message.reasoning_content = reasoning_content
+    if thinking_blocks is not None:
+        message.thinking_blocks = thinking_blocks
     choice = SimpleNamespace(message=message, finish_reason='stop', index=0)
     return SimpleNamespace(choices=[choice], id='cmpl-test', model='test')
+
+
+def _fake_stream_chunk(content='hi', reasoning_content=None):
+    """Build a minimal LiteLLM streaming chunk stand-in."""
+    delta = SimpleNamespace(content=content)
+    if reasoning_content is not None:
+        delta.reasoning_content = reasoning_content
+    choice = SimpleNamespace(delta=delta, finish_reason=None, index=0)
+    return SimpleNamespace(choices=[choice])
 
 
 class TestLiteLLMAPIInit(unittest.TestCase):
@@ -89,11 +103,35 @@ class TestLiteLLMAPIInit(unittest.TestCase):
         )
         self.assertTrue(kwargs['drop_params'])
 
+    def test_stream_default_omits_stream_kwarg(self):
+        model = LiteLLMAPI(path='openai/gpt-4o-mini')
+        kwargs = model._build_call_kwargs(
+            messages=[{'role': 'user', 'content': 'hi'}],
+            max_out_len=128,
+        )
+        self.assertNotIn('stream', kwargs)
+
+    def test_stream_true_forwards_stream_kwarg(self):
+        model = LiteLLMAPI(path='openai/gpt-4o-mini', stream=True)
+        kwargs = model._build_call_kwargs(
+            messages=[{'role': 'user', 'content': 'hi'}],
+            max_out_len=128,
+        )
+        self.assertTrue(kwargs['stream'])
+
+    def test_think_tag_default(self):
+        model = LiteLLMAPI(path='openai/gpt-4o-mini')
+        self.assertEqual(model.think_tag, '</think>')
+
     def test_extra_body_cannot_override_core_params(self):
-        """extra_body should not override model, messages, or max_tokens."""
+        """extra_body should not override core request fields."""
         model = LiteLLMAPI(
             path='openai/gpt-4o-mini',
-            extra_body={'model': 'WRONG', 'max_tokens': 999},
+            extra_body={
+                'model': 'WRONG',
+                'max_tokens': 999,
+                'stream': True,
+            },
         )
         kwargs = model._build_call_kwargs(
             messages=[{'role': 'user', 'content': 'hi'}],
@@ -101,6 +139,32 @@ class TestLiteLLMAPIInit(unittest.TestCase):
         )
         self.assertEqual(kwargs['model'], 'openai/gpt-4o-mini')
         self.assertEqual(kwargs['max_tokens'], 128)
+        self.assertNotIn('stream', kwargs)
+
+    def test_gen_kwargs_forwarded_without_overriding_core_params(self):
+        model = LiteLLMAPI(path='openai/gpt-4o-mini')
+        messages = [{'role': 'user', 'content': 'hi'}]
+        kwargs = model._build_call_kwargs(
+            messages=messages,
+            max_out_len=128,
+            gen_kwargs={
+                'model': 'WRONG',
+                'messages': [{'role': 'user', 'content': 'WRONG'}],
+                'max_tokens': 999,
+                'drop_params': False,
+                'stream': True,
+                'top_p': 0.9,
+                'seed': 42,
+            },
+        )
+
+        self.assertEqual(kwargs['model'], 'openai/gpt-4o-mini')
+        self.assertEqual(kwargs['messages'], messages)
+        self.assertEqual(kwargs['max_tokens'], 128)
+        self.assertTrue(kwargs['drop_params'])
+        self.assertNotIn('stream', kwargs)
+        self.assertEqual(kwargs['top_p'], 0.9)
+        self.assertEqual(kwargs['seed'], 42)
 
 
 class TestLiteLLMAPIMessages(unittest.TestCase):
@@ -147,6 +211,23 @@ class TestLiteLLMAPIMessages(unittest.TestCase):
                 'role': 'assistant',
                 'content': 'Hello!'
             },
+            {
+                'role': 'user',
+                'content': 'What is 2+2?'
+            },
+        ])
+
+    def test_opencompass_native_plain_list(self):
+        """Parallel inferencers may pass a plain list instead of PromptList."""
+        model = LiteLLMAPI(path='openai/gpt-4o-mini')
+        prompt_list = [
+            {
+                'role': 'HUMAN',
+                'prompt': 'What is 2+2?'
+            },
+        ]
+        messages = model._build_messages(prompt_list)
+        self.assertEqual(messages, [
             {
                 'role': 'user',
                 'content': 'What is 2+2?'
@@ -223,6 +304,124 @@ class TestLiteLLMAPIGenerate(unittest.TestCase):
                          }])
         self.assertEqual(kwargs['max_tokens'], 32)
         self.assertEqual(kwargs['api_key'], 'sk-test')
+
+    def test_generate_forwards_gen_kwargs(self):
+        completion = _install_litellm_stub()
+        completion.return_value = _fake_response('pong')
+
+        model = LiteLLMAPI(path='openai/gpt-4o-mini')
+        results = model.generate(['ping'],
+                                 max_out_len=32,
+                                 top_p=0.9,
+                                 seed=42)
+
+        self.assertEqual(results, ['pong'])
+        kwargs = completion.call_args.kwargs
+        self.assertEqual(kwargs['top_p'], 0.9)
+        self.assertEqual(kwargs['seed'], 42)
+
+    def test_generate_stream_response(self):
+        completion = _install_litellm_stub()
+        completion.return_value = iter([
+            _fake_stream_chunk('Lite'),
+            _fake_stream_chunk(None),
+            _fake_stream_chunk('LLM'),
+            _fake_stream_chunk(' OK'),
+        ])
+
+        model = LiteLLMAPI(path='openai/gpt-4o-mini', stream=True)
+        results = model.generate(['ping'], max_out_len=32)
+
+        self.assertEqual(results, ['LiteLLM OK'])
+        kwargs = completion.call_args.kwargs
+        self.assertTrue(kwargs['stream'])
+
+    def test_generate_with_reasoning_content(self):
+        completion = _install_litellm_stub()
+        completion.return_value = _fake_response(
+            'Final answer',
+            reasoning_content='Thinking process',
+        )
+
+        model = LiteLLMAPI(path='openai/gpt-4o-mini')
+        results = model.generate(['ping'], max_out_len=32)
+
+        self.assertEqual(results, ['Thinking process</think>Final answer'])
+
+    def test_generate_with_custom_think_tag(self):
+        completion = _install_litellm_stub()
+        completion.return_value = _fake_response(
+            'Final answer',
+            reasoning_content='Thinking process',
+        )
+
+        model = LiteLLMAPI(path='openai/gpt-4o-mini',
+                           think_tag='<THINK_END>')
+        results = model.generate(['ping'], max_out_len=32)
+
+        self.assertEqual(results,
+                         ['Thinking process<THINK_END>Final answer'])
+
+    def test_generate_with_thinking_blocks_fallback(self):
+        completion = _install_litellm_stub()
+        completion.return_value = _fake_response(
+            'Final answer',
+            thinking_blocks=[{
+                'type': 'thinking',
+                'thinking': 'Thinking process',
+                'signature': 'test',
+            }],
+        )
+
+        model = LiteLLMAPI(path='anthropic/claude-sonnet-4')
+        results = model.generate(['ping'], max_out_len=32)
+
+        self.assertEqual(results, ['Thinking process</think>Final answer'])
+
+    def test_generate_stream_response_with_reasoning_content(self):
+        completion = _install_litellm_stub()
+        completion.return_value = iter([
+            _fake_stream_chunk(None, reasoning_content='Thinking'),
+            _fake_stream_chunk(None, reasoning_content=' process'),
+            _fake_stream_chunk('Answer'),
+        ])
+
+        model = LiteLLMAPI(path='openai/gpt-4o-mini', stream=True)
+        results = model.generate(['ping'], max_out_len=32)
+
+        self.assertEqual(results, ['Thinking process</think>Answer'])
+
+    def test_generate_adjusts_max_out_len_by_max_seq_len(self):
+        completion = _install_litellm_stub()
+        completion.return_value = _fake_response('pong')
+
+        model = LiteLLMAPI(path='openai/gpt-4o-mini', max_seq_len=105)
+        results = model.generate(['one two three'], max_out_len=10)
+
+        self.assertEqual(results, ['pong'])
+        kwargs = completion.call_args.kwargs
+        self.assertEqual(kwargs['max_tokens'], 2)
+
+    def test_generate_raises_when_prompt_exceeds_max_seq_len(self):
+        completion = _install_litellm_stub()
+        completion.return_value = _fake_response('pong')
+
+        model = LiteLLMAPI(path='openai/gpt-4o-mini', max_seq_len=2)
+        with self.assertRaisesRegex(ValueError, 'exceeds max_seq_len'):
+            model.generate(['one two three'], max_out_len=1)
+
+        completion.assert_not_called()
+
+    def test_generate_raises_when_no_output_room_remains(self):
+        completion = _install_litellm_stub()
+        completion.return_value = _fake_response('pong')
+
+        model = LiteLLMAPI(path='openai/gpt-4o-mini', max_seq_len=102)
+        with self.assertRaisesRegex(ValueError,
+                                    'less than or equal to 0'):
+            model.generate(['one two three'], max_out_len=10)
+
+        completion.assert_not_called()
 
     def test_generate_preserves_batch_order(self):
         completion = _install_litellm_stub()


### PR DESCRIPTION
  ## Motivation                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                          
  OpenCompass currently requires a separate provider file for each LLM backend. Users who want to evaluate models across Azure, Bedrock, Vertex AI, or Groq need provider-specific code. [LiteLLM](https://github.com/BerriAI/litellm) provides a unified `completion()` interface that handles auth, formatting, and provider-specific quirks, enabling cross-provider   
  evaluation with a single configuration change.
                                                                                                                                                                                                                                                                                                                                                                          
  Supersedes stale PR #202 (ishaan-jaff, Aug 2023) -- both review points from @gaotongxiao addressed: optional dep in `requirements/api.txt` (not core), lazy import inside `_generate()`.                                                                                                                                                                                
   
  Also addresses provider flexibility mentioned in #2147 -- AI/ML API is accessible via LiteLLM as `aiml/<model>`.                                                                                                                                                                                                                                                        
                  
  ## Modification                                                                                                                                                                                                                                                                                                                                                         
                  
  - `opencompass/models/litellm_api.py` -- new `LiteLLMAPI` extending `BaseAPIModel` (236 lines). Handles all 3 input formats: plain `str`, CHATML-shaped dicts, and OpenCompass-native `PromptList` (`HUMAN`/`BOT`/`SYSTEM`).                                                                                                                                            
  - `opencompass/models/__init__.py` -- import + registration in alphabetical order
  - `requirements/api.txt` -- added `litellm>=1.55,<1.85`                                                                                                                                                                                                                                                                                                                 
  - `docs/en/user_guides/models.md` -- added LiteLLM to supported API providers list
  - `docs/zh_cn/user_guides/models.md` -- added LiteLLM to supported API providers list (Chinese)                                                                                                                                                                                                                                                                         
  - `tests/models/test_litellm_api.py` -- 18 unit tests covering init, message translation, generation, retry, error handling, registry                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                          
  Key details:                                                                                                                                                                                                                                                                                                                                                            
  - `drop_params=True` by default -- silently drops provider-unsupported kwargs for cross-provider compatibility                                                                                                                                                                                                                                                          
  - Lazy `import litellm` inside `_generate()` -- base install unaffected                                                                                                                                                                                                                                                                                                 
  - Flexible auth: accepts `key=` param or provider-specific env vars (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.)
  - `extra_body` dict for forwarding provider-specific params (`reasoning_effort`, `seed`, etc.)                                                                                                                                                                                                                                                                          
                  
  ## BC-breaking                                                                                                                                                                                                                                                                                                                                                          
                  
  None. Additive only -- existing providers untouched. `litellm` is in `requirements/api.txt` (optional extra), not in the base `requirements.txt`.                                                                                                                                                                                                                       
   
  ## Usage and Testing                                                                                                                                                                                                                                                                                                                                                            
                  
  ```python
  from opencompass.models import LiteLLMAPI

  models = [
      dict(
          type=LiteLLMAPI,
          path='anthropic/claude-sonnet-4-20250514',  # any LiteLLM model string                                                                                                                                                                                                                                                                                          
          temperature=0,
          max_seq_len=16384,                                                                                                                                                                                                                                                                                                                                              
          query_per_second=2,
          retry=2,
      ),                                                                                                                                                                                                                                                                                                                                                                  
  ]
  ```
                                                                                                                                                                                                                                                                                                                                                                          
  Supported model strings include:
  - OpenAI: gpt-4o, gpt-4o-mini
  - Anthropic: anthropic/claude-sonnet-4-20250514
  - Azure: azure/gpt-4o                          
  - Bedrock: bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0
  - Vertex AI: vertex_ai/gemini-2.5-pro                                                                                                                                                                                                                                                                                                                                   
  - Together AI: together_ai/meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo
  - Groq: groq/meta-llama/llama-4-scout-17b-16e-instruct                                                                                                                                                                                                                                                                                                                  
  - 100+ more at https://docs.litellm.ai/docs/providers                                                                                                                                                                                                                                                                                                                   


```   
  Unit tests (18/18 pass):                                                                                                                                                                                                                                                                                                                                                
                  
  tests/models/test_litellm_api.py::TestLiteLLMAPIInit::test_call_kwargs_forwards_provider_credentials PASSED                                                                                                                                                                                                                                                             
  tests/models/test_litellm_api.py::TestLiteLLMAPIInit::test_call_kwargs_omits_optional_when_blank PASSED                                                                                                                                                                                                                                                                 
  tests/models/test_litellm_api.py::TestLiteLLMAPIInit::test_default_init_stores_path PASSED
  tests/models/test_litellm_api.py::TestLiteLLMAPIInit::test_drop_params_default_true PASSED                                                                                                                                                                                                                                                                              
  tests/models/test_litellm_api.py::TestLiteLLMAPIInit::test_extra_body_cannot_override_core_params PASSED
  tests/models/test_litellm_api.py::TestLiteLLMAPIInit::test_registers_in_models_registry PASSED                                                                                                                                                                                                                                                                          
  tests/models/test_litellm_api.py::TestLiteLLMAPIMessages::test_chatml_shaped_prompt_list_passes_through PASSED
  tests/models/test_litellm_api.py::TestLiteLLMAPIMessages::test_opencompass_native_prompt_list PASSED                                                                                                                                                                                                                                                                    
  tests/models/test_litellm_api.py::TestLiteLLMAPIMessages::test_plain_string_input PASSED                                                                                                                                                                                                                                                                                
  tests/models/test_litellm_api.py::TestLiteLLMAPIMessages::test_system_prompt_not_duplicated_when_system_exists PASSED                                                                                                                                                                                                                                                   
  tests/models/test_litellm_api.py::TestLiteLLMAPIMessages::test_system_prompt_prepended_when_absent PASSED                                                                                                                                                                                                                                                               
  tests/models/test_litellm_api.py::TestLiteLLMAPIGenerate::test_generate_handles_none_content PASSED
  tests/models/test_litellm_api.py::TestLiteLLMAPIGenerate::test_generate_preserves_batch_order PASSED                                                                                                                                                                                                                                                                    
  tests/models/test_litellm_api.py::TestLiteLLMAPIGenerate::test_generate_raises_after_exhausting_retries PASSED                                                                                                                                                                                                                                                          
  tests/models/test_litellm_api.py::TestLiteLLMAPIGenerate::test_generate_raises_import_error_without_litellm PASSED                                                                                                                                                                                                                                                      
  tests/models/test_litellm_api.py::TestLiteLLMAPIGenerate::test_generate_retries_then_succeeds PASSED                                                                                                                                                                                                                                                                    
  tests/models/test_litellm_api.py::TestLiteLLMAPIGenerate::test_generate_single_string PASSED
  tests/models/test_litellm_api.py::TestLiteLLMAPIGenerate::test_generate_translates_opencompass_native_prompt_list PASSED                                                                                                                                                                                                                                                
  ======================== 18 passed in 4.71s ========================                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                          
  Live E2E against Anthropic Claude Sonnet 4-6 (via Azure):                                                                                                                                                                                                                                                                                                               
                  
  ============================================================
  Live E2E Test: opencompass LiteLLMAPI
  Model: anthropic/claude-sonnet-4-6                                                                                                                                                                                                                                                                                                                                      
  ============================================================
                                                                                                                                                                                                                                                                                                                                                                          
  [Test 1] Plain string input
    Answer: 4

  [Test 2] OpenCompass PromptList (HUMAN/BOT roles)                                                                                                                                                                                                                                                                                                                       
    Answer: The square root of 144 is 12.
                                                                                                                                                                                                                                                                                                                                                                          
  [Test 3] Batch generation (3 inputs)
    [0] Hello!
    [1] Goodbye!
    [2] Thanks!

  ============================================================
  All 3 tests passed
  ============================================================
```
                                                                                                                                                                                                                                                                                                                                                                          
  Lint: flake8 --max-line-length 99 + isort --check -> all clean.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
