### PR TITLE
fix: handle dict output in SmolInstructDataset.load for SIDER subset

### DIFF
--- a/opencompass/datasets/smolinstruct.py
+++ b/opencompass/datasets/smolinstruct.py
@@ -1,4 +1,6 @@
 # flake8: noqa: W605
+import json
+import random
 import re
 from collections import defaultdict
 
@@ -25,6 +27,15 @@ class SmolInstructDataset(BaseDataset):
             raw_data = []
             for data in raw_dataset[split]:
                 if data['task'] == name:
+                    # Some subsets (e.g., property_prediction-sider) store
+                    # 'output' as a multi-label dict instead of a plain string,
+                    # which causes a casting error when building the Dataset.
+                    # Serialize dict outputs to a JSON string so the 'output'
+                    # column has a uniform string type across all subsets.
+                    if isinstance(data.get('output'), dict):
+                        data = dict(data)
+                        data['output'] = json.dumps(data['output'],
+                                                    ensure_ascii=False)
                     raw_data.append(data)
             if mini_set and split == 'test':
                 random.seed(1024)


### PR DESCRIPTION
Fixes #2440

## Problem

The `property_prediction-sider` subset of SMolInstruct stores the `output` field as a multi-label dict (one entry per side-effect category) rather than a plain string like every other subset. When HuggingFace Arrow tries to build a Dataset from rows that mix string and struct-typed outputs, it raises:

```
TypeError: Couldn't cast array of type struct<Hepatobiliary disorders: string, ...> to string
```

Additionally, `random` was used by the existing `mini_set` sampling code but was never imported, which would cause a `NameError` whenever `mini_set=True`.

## Solution

In `opencompass/datasets/smolinstruct.py`:

1. Before appending each row to `raw_data`, check whether the `output` field is a dict; if so, serialize it to a JSON string. This ensures `Dataset.from_list()` always receives a uniform `string`-typed column regardless of the subset.
2. Add the missing `import json` and `import random` statements.

## Testing

The fix can be verified by running the pp-acc evaluation config that includes the SIDER subset:

```bash
opencompass config.py --reuse
```

where `config.py` imports `mini_pp_acc_datasets_0shot_instruct` (which includes `PP-SIDER-0shot-instruct-mini`). Previously this raised a `TypeError`; with this fix the dataset loads cleanly.