### PR TITLE
[Fix] Avoid scoring invalid SIQA generations as correct

### DIFF
--- a/opencompass/configs/datasets/collections/chat_medium.py
+++ b/opencompass/configs/datasets/collections/chat_medium.py
@@ -45,7 +45,7 @@ with read_base():
     from ..ARC_c.ARC_c_gen_1e0de5 import ARC_c_datasets
     from ..commonsenseqa.commonsenseqa_gen_c946f2 import commonsenseqa_datasets
     from ..piqa.piqa_gen_1194eb import piqa_datasets
-    from ..siqa.siqa_gen_e78df3 import siqa_datasets
+    from ..siqa.siqa_gen_18632c import siqa_datasets
     from ..strategyqa.strategyqa_gen_1180a7 import strategyqa_datasets
     from ..winogrande.deprecated_winogrande_gen_a9ede5 import winogrande_datasets
     from ..obqa.obqa_gen_9069e4 import obqa_datasets

--- a/opencompass/configs/datasets/siqa/siqa_gen.py
+++ b/opencompass/configs/datasets/siqa/siqa_gen.py
@@ -1,4 +1,4 @@
 from mmengine.config import read_base
 
 with read_base():
-    from .siqa_gen_e78df3 import siqa_datasets  # noqa: F401, F403
+    from .siqa_gen_18632c import siqa_datasets  # noqa: F401, F403

--- a/opencompass/configs/datasets/siqa/siqa_gen_18632c.py
+++ b/opencompass/configs/datasets/siqa/siqa_gen_18632c.py
@@ -27,8 +27,9 @@ siqa_infer_cfg = dict(
 )
 
 siqa_eval_cfg = dict(
-            evaluator=dict(type=AccEvaluator),
-            pred_postprocessor=dict(type=first_option_postprocess, options='ABC')
+    evaluator=dict(type=AccEvaluator),
+    pred_postprocessor=dict(
+        type=first_option_postprocess, options='ABC', cushion=False)
 )
 
 siqa_datasets = [

--- a/tests/datasets/test_siqa_config.py
+++ b/tests/datasets/test_siqa_config.py
@@ -1,0 +1,128 @@
+"""Tests for SIQA dataset configuration defaults."""
+
+import contextlib
+import importlib
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SIQA_CONFIG_DIR = REPO_ROOT / 'opencompass' / 'configs' / 'datasets' / 'siqa'
+
+
+class AccEvaluator:
+    pass
+
+
+class GenInferencer:
+    pass
+
+
+class PromptTemplate:
+    pass
+
+
+class SiqaDatasetV3:
+    pass
+
+
+class ZeroRetriever:
+    pass
+
+
+def first_option_postprocess(text, options, cushion=True):
+    pass
+
+
+def _make_package(name, path=None):
+    module = types.ModuleType(name)
+    module.__path__ = [] if path is None else [str(path)]
+    return module
+
+
+def _make_module(name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    return module
+
+
+def _make_stubs():
+    return {
+        'mmengine':
+        _make_package('mmengine'),
+        'mmengine.config':
+        _make_module('mmengine.config',
+                     read_base=lambda: contextlib.nullcontext()),
+        'opencompass':
+        _make_package('opencompass', REPO_ROOT / 'opencompass'),
+        'opencompass.configs':
+        _make_package('opencompass.configs',
+                      REPO_ROOT / 'opencompass' / 'configs'),
+        'opencompass.configs.datasets':
+        _make_package('opencompass.configs.datasets',
+                      REPO_ROOT / 'opencompass' / 'configs' / 'datasets'),
+        'opencompass.configs.datasets.siqa':
+        _make_package('opencompass.configs.datasets.siqa', SIQA_CONFIG_DIR),
+        'opencompass.openicl':
+        _make_package('opencompass.openicl'),
+        'opencompass.openicl.icl_prompt_template':
+        _make_module('opencompass.openicl.icl_prompt_template',
+                     PromptTemplate=PromptTemplate),
+        'opencompass.openicl.icl_retriever':
+        _make_module('opencompass.openicl.icl_retriever',
+                     ZeroRetriever=ZeroRetriever),
+        'opencompass.openicl.icl_inferencer':
+        _make_module('opencompass.openicl.icl_inferencer',
+                     GenInferencer=GenInferencer),
+        'opencompass.openicl.icl_evaluator':
+        _make_module('opencompass.openicl.icl_evaluator',
+                     AccEvaluator=AccEvaluator),
+        'opencompass.datasets':
+        _make_module('opencompass.datasets', SiqaDatasetV3=SiqaDatasetV3),
+        'opencompass.utils':
+        _make_package('opencompass.utils'),
+        'opencompass.utils.text_postprocessors':
+        _make_module('opencompass.utils.text_postprocessors',
+                     first_option_postprocess=first_option_postprocess),
+    }
+
+
+def _drop_modules(module_names):
+    for module_name in module_names:
+        sys.modules.pop(module_name, None)
+
+
+class TestSIQAConfig(unittest.TestCase):
+
+    def setUp(self):
+        module_names = [
+            'opencompass.configs.datasets.siqa.siqa_gen',
+            'opencompass.configs.datasets.siqa.siqa_gen_18632c',
+        ]
+        _drop_modules(module_names)
+
+        self.module_patch = patch.dict(sys.modules, _make_stubs())
+        self.module_patch.start()
+        self.addCleanup(self.module_patch.stop)
+        self.addCleanup(_drop_modules, module_names)
+
+    def test_default_siqa_gen_uses_strict_accuracy_config(self):
+        module = importlib.import_module(
+            'opencompass.configs.datasets.siqa.siqa_gen')
+
+        dataset = module.siqa_datasets[0]
+        eval_cfg = dataset['eval_cfg']
+
+        self.assertIs(dataset['type'], SiqaDatasetV3)
+        self.assertIs(eval_cfg['evaluator']['type'], AccEvaluator)
+        self.assertIs(eval_cfg['pred_postprocessor']['type'],
+                      first_option_postprocess)
+        self.assertEqual(eval_cfg['pred_postprocessor']['options'], 'ABC')
+        self.assertFalse(eval_cfg['pred_postprocessor']['cushion'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Switch the default SIQA generation config to the stricter option-extraction accuracy config instead of edit-distance matching.
- Update the chat medium collection to use the same SIQA gen config.
- Disable the broad cushion fallback for SIQA option extraction so invalid text is not coerced into A/B/C.
- Add a focused regression test that verifies the default SIQA gen config uses strict accuracy scoring.

Fixes #2329

## Tests
- `python3 -m pytest tests/datasets/test_siqa_config.py -q`
- `python3 -m isort --check-only tests/datasets/test_siqa_config.py`
- `python3 -m yapf --diff tests/datasets/test_siqa_config.py`
- `python3 -m flake8 tests/datasets/test_siqa_config.py`
- `python3 -m py_compile opencompass/configs/datasets/siqa/siqa_gen.py opencompass/configs/datasets/siqa/siqa_gen_18632c.py opencompass/configs/datasets/collections/chat_medium.py tests/datasets/test_siqa_config.py`
- `git diff --check`