### PR TITLE
[Fix] Combine split eval results in default summarizer

### DIFF
--- a/opencompass/summarizers/default.py
+++ b/opencompass/summarizers/default.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 # yapf: disable
 import functools
+import glob
 import getpass
 import math
 import os.path as osp
@@ -15,6 +16,7 @@ from opencompass.utils import (LarkReporter, dataset_abbr_from_cfg,
                                get_infer_output_path, get_logger,
                                model_abbr_from_cfg)
 from opencompass.utils.prompt import get_prompt_hash
+from opencompass.utils.result import RESULT_METADATA_KEY, SAMPLE_COUNT_KEY
 
 METRIC_WHITELIST = ['score', 'auc_score', 'accuracy', 'humaneval_pass@1', 'rouge1', 'avg_toxicity_score', 'bleurt_diff', 'matthews_correlation', 'truth', 'f1', 'exact_match', 'extract_rate']
 METRIC_BLACKLIST = ['bp', 'sys_len', 'ref_len', 'type']
@@ -64,6 +66,107 @@ class DefaultSummarizer:
             model_abbrs.append(model_abbr)
         self.model_abbrs = model_abbrs
 
+    def _load_result(self, filepath):
+        if osp.exists(filepath):
+            return mmengine.load(filepath)
+        return self._load_split_results(filepath)
+
+    def _load_split_results(self, filepath):
+        split_paths = self._find_split_result_paths(filepath)
+        if not split_paths:
+            return None
+
+        split_results = [(path, mmengine.load(path)) for path in split_paths]
+        return self._combine_split_results(filepath, split_results)
+
+    def _find_split_result_paths(self, filepath):
+        root, ext = osp.splitext(filepath)
+        pattern = glob.escape(root) + '_*' + ext
+        split_indices_and_paths = []
+        for path in glob.glob(pattern):
+            suffix = path[len(root) + 1:-len(ext)] if ext else path[len(root) + 1:]
+            if suffix.isdigit():
+                split_indices_and_paths.append((int(suffix), path))
+
+        if not split_indices_and_paths:
+            return []
+
+        split_indices_and_paths.sort()
+        split_indices = [index for index, _ in split_indices_and_paths]
+        expected_indices = list(range(split_indices[-1] + 1))
+        if split_indices != expected_indices:
+            self.logger.warning(
+                f'skip incomplete split results for {filepath}: '
+                f'found split indices {split_indices}, expected {expected_indices}')
+            return []
+
+        return [path for _, path in split_indices_and_paths]
+
+    def _combine_split_results(self, filepath, split_results):
+        sample_counts = []
+        for split_path, result in split_results:
+            if 'error' in result:
+                return {'error': f'{split_path}: {result["error"]}'}
+
+            sample_count = self._get_result_sample_count(result)
+            if sample_count is None:
+                self.logger.warning(
+                    f'skip split results for {filepath}: '
+                    f'{split_path} does not contain sample count metadata or details')
+                return None
+            sample_counts.append(sample_count)
+
+        total_samples = sum(sample_counts)
+        if total_samples <= 0:
+            self.logger.warning(f'skip split results for {filepath}: no samples found')
+            return None
+
+        metric_sets = []
+        for _, result in split_results:
+            metric_sets.append({
+                metric
+                for metric, score in result.items()
+                if metric not in (METRIC_BLACKLIST + [RESULT_METADATA_KEY, 'details'])
+                and isinstance(score, (int, float))
+            })
+
+        common_metrics = set.intersection(*metric_sets) if metric_sets else set()
+        if not common_metrics:
+            self.logger.warning(
+                f'skip split results for {filepath}: no common numeric metrics found')
+            return None
+
+        merged_result = {}
+        for metric in sorted(common_metrics):
+            merged_result[metric] = sum(
+                result[metric] * sample_count
+                for (_, result), sample_count in zip(split_results, sample_counts)) / total_samples
+        merged_result[RESULT_METADATA_KEY] = {SAMPLE_COUNT_KEY: total_samples}
+        return merged_result
+
+    @staticmethod
+    def _get_result_sample_count(result):
+        metadata = result.get(RESULT_METADATA_KEY)
+        if isinstance(metadata, dict):
+            sample_count = metadata.get(SAMPLE_COUNT_KEY)
+            if isinstance(sample_count, int):
+                return sample_count
+
+        details = result.get('details')
+        if isinstance(details, list):
+            return len(details)
+        if isinstance(details, dict):
+            sample_details = {k: v for k, v in details.items() if k != 'type'}
+            if not sample_details:
+                return 0
+            if all(isinstance(v, dict) for v in sample_details.values()):
+                return len(sample_details)
+            if len(sample_details) == 1:
+                values = next(iter(sample_details.values()))
+                if isinstance(values, list):
+                    return len(values)
+        return None
+
     def _pick_up_results(self):
         """The function reads the numerical results of evaluations from the
         output folder based on the configuration file, and ultimately returns
@@ -90,10 +193,11 @@ class DefaultSummarizer:
             for dataset in self.dataset_cfgs:
                 dataset_abbr = dataset_abbr_from_cfg(dataset)
                 filepath = get_infer_output_path(model, dataset, osp.join(self.work_dir, 'results'))
-                if not osp.exists(filepath):
+                result = self._load_result(filepath)
+                if result is None:
                     continue
-                result = mmengine.load(filepath)
                 result.pop('details', None)
+                result.pop(RESULT_METADATA_KEY, None)
                 raw_results[model_abbr][dataset_abbr] = result
                 if 'error' in result:
                     self.logger.debug(f'error in {model_abbr} {dataset_abbr} {result["error"]}')

--- a/opencompass/tasks/openicl_eval.py
+++ b/opencompass/tasks/openicl_eval.py
@@ -23,6 +23,7 @@ from opencompass.registry import (ICL_EVALUATORS, MODELS, TASKS,
 from opencompass.tasks.base import BaseTask, extract_role_pred
 from opencompass.utils import (build_dataset_from_cfg, get_infer_output_path,
                                get_logger)
+from opencompass.utils.result import RESULT_METADATA_KEY, SAMPLE_COUNT_KEY
 
 
 @TASKS.register_module()
@@ -113,9 +114,6 @@ class OpenICLEvalTask(BaseTask):
                 pred_dicts,
             )
 
-            # Save results
-            self._save_results(result)
-
         else:
             # Process predictions
             pred_strs = self._process_predictions(pred_strs)
@@ -127,8 +125,19 @@ class OpenICLEvalTask(BaseTask):
                 pred_dicts,
             )
 
-            # Save results
-            self._save_results(result)
+        self._record_result_metadata(result, len(test_set))
+
+        # Save results
+        self._save_results(result)
+
+    @staticmethod
+    def _record_result_metadata(result, num_samples):
+        """Record lightweight metadata needed by result consumers."""
+        metadata = result.get(RESULT_METADATA_KEY)
+        if not isinstance(metadata, dict):
+            metadata = {}
+        metadata.setdefault(SAMPLE_COUNT_KEY, num_samples)
+        result[RESULT_METADATA_KEY] = metadata
 
     def _load_and_preprocess_test_data(self):
         """Load test dataset and apply postprocessing if needed."""

--- a/opencompass/utils/__init__.py
+++ b/opencompass/utils/__init__.py
@@ -14,5 +14,6 @@ from .logging import *  # noqa
 from .menu import *  # noqa
 from .network import *  # noqa
 from .prompt import *  # noqa
+from .result import *  # noqa
 from .result_station import *  # noqa
 from .text_postprocessors import *  # noqa

--- a/opencompass/utils/result.py
+++ b/opencompass/utils/result.py
@@ -1,0 +1,4 @@
+"""Shared helpers for evaluation result files."""
+
+RESULT_METADATA_KEY = '_opencompass_meta'
+SAMPLE_COUNT_KEY = 'num_samples'

--- a/tests/summarizers/test_default.py
+++ b/tests/summarizers/test_default.py
@@ -1,12 +1,16 @@
 """Unit tests for DefaultSummarizer."""
 
+import os.path as osp
+import shutil
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
+import mmengine
 from mmengine.config import ConfigDict
 
 from opencompass.summarizers.default import DefaultSummarizer
+from opencompass.utils.result import RESULT_METADATA_KEY, SAMPLE_COUNT_KEY
 
 
 class TestDefaultSummarizer(unittest.TestCase):
@@ -14,12 +18,32 @@ class TestDefaultSummarizer(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
         self.config = ConfigDict({
             'work_dir':
-            tempfile.mkdtemp(),
+            self.temp_dir,
             'models': [ConfigDict({'abbr': 'test_model'})],
-            'datasets': [ConfigDict({'abbr': 'test_dataset'})]
+            'datasets': [
+                ConfigDict({
+                    'abbr': 'test_dataset',
+                    'infer_cfg': {
+                        'inferencer': {
+                            'type': 'GenInferencer'
+                        }
+                    }
+                })
+            ]
         })
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        shutil.rmtree(self.temp_dir)
+
+    def dump_result(self, dataset_abbr, result):
+        """Dump a result file for the default test model."""
+        result_dir = osp.join(self.temp_dir, 'results', 'test_model')
+        mmengine.mkdir_or_exist(result_dir)
+        mmengine.dump(result, osp.join(result_dir, f'{dataset_abbr}.json'))
 
     def test_initialization(self):
         """Test DefaultSummarizer initialization."""
@@ -55,6 +79,68 @@ class TestDefaultSummarizer(unittest.TestCase):
 
             # Should log a warning about prompt_db being deprecated
             mock_log.warning.assert_called()
+
+    def test_pick_up_results_combines_split_results_with_details(self):
+        """Test summarizer combines legacy split result files using details."""
+        self.dump_result('test_dataset_0', {
+            'accuracy': 80.0,
+            'details': [{}, {}],
+        })
+        self.dump_result('test_dataset_1', {
+            'accuracy': 100.0,
+            'details': [{}],
+        })
+
+        summarizer = DefaultSummarizer(config=self.config)
+        raw_results, parsed_results, dataset_metrics, _ = \
+            summarizer._pick_up_results()
+
+        self.assertAlmostEqual(
+            parsed_results['test_model']['test_dataset']['accuracy'],
+            86.6666666667)
+        self.assertEqual(dataset_metrics['test_dataset'], ['accuracy'])
+        self.assertNotIn('details',
+                         raw_results['test_model']['test_dataset'])
+
+    def test_pick_up_results_combines_split_results_with_metadata(self):
+        """Test summarizer combines split result files without details."""
+        self.dump_result('test_dataset_0', {
+            'accuracy': 50.0,
+            RESULT_METADATA_KEY: {
+                SAMPLE_COUNT_KEY: 2
+            },
+        })
+        self.dump_result('test_dataset_1', {
+            'accuracy': 100.0,
+            RESULT_METADATA_KEY: {
+                SAMPLE_COUNT_KEY: 1
+            },
+        })
+
+        summarizer = DefaultSummarizer(config=self.config)
+        raw_results, parsed_results, _, _ = summarizer._pick_up_results()
+
+        self.assertAlmostEqual(
+            parsed_results['test_model']['test_dataset']['accuracy'],
+            66.6666666667)
+        self.assertNotIn(RESULT_METADATA_KEY,
+                         raw_results['test_model']['test_dataset'])
+
+    def test_pick_up_results_prefers_complete_result_file(self):
+        """Test unsplit result files take precedence over split files."""
+        self.dump_result('test_dataset', {'accuracy': 70.0})
+        self.dump_result('test_dataset_0', {
+            'accuracy': 50.0,
+            RESULT_METADATA_KEY: {
+                SAMPLE_COUNT_KEY: 1
+            },
+        })
+
+        summarizer = DefaultSummarizer(config=self.config)
+        _, parsed_results, _, _ = summarizer._pick_up_results()
+
+        self.assertEqual(
+            parsed_results['test_model']['test_dataset']['accuracy'], 70.0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- combine numbered split result files in the default summarizer when the unsplit result file is absent
- weight merged numeric metrics by sample counts from result metadata or legacy details
- record per-result sample counts from OpenICLEvalTask for future split runs without details

Fixes #2163

## Tests
- python3 -m flake8 tests/summarizers/test_default.py opencompass/tasks/openicl_eval.py opencompass/utils/result.py
- python3 -m py_compile opencompass/summarizers/default.py opencompass/tasks/openicl_eval.py opencompass/utils/result.py tests/summarizers/test_default.py
- python3 -m pytest tests/summarizers/test_default.py (blocked locally: missing torch runtime dependency)