### PR TITLE
[Fix] Restore LongBench v2 answer prompt punctuation

### DIFF
--- a/opencompass/configs/datasets/longbenchv2/longbenchv2_gen_75fbba.py
+++ b/opencompass/configs/datasets/longbenchv2/longbenchv2_gen_75fbba.py
@@ -16,7 +16,7 @@ LongBenchv2_infer_cfg = dict(
             round=[
                 dict(
                     role='HUMAN',
-                    prompt='Please read the following text and answer the questions below.\n <text> \n {context} \n </text> \n \n What is the correct answer to this question: {question} \n \n Choices: \n (A) {choice_A} \n (B) {choice_B} \n (C) {choice_C} \n (D) {choice_D} \n Let’s think step by step. Based on the above, what is the single, most likely answer choice? Format your response as follows: "The correct answer is (insert answer here)',
+                    prompt='Please read the following text and answer the questions below.\n <text> \n {context} \n </text> \n \n What is the correct answer to this question: {question} \n \n Choices: \n (A) {choice_A} \n (B) {choice_B} \n (C) {choice_C} \n (D) {choice_D} \n Let’s think step by step. Based on the above, what is the single, most likely answer choice? Format your response as follows: "The correct answer is (insert answer here)".',
                 ),
             ],
         ),

--- a/tests/datasets/test_longbenchv2_config.py
+++ b/tests/datasets/test_longbenchv2_config.py
@@ -1,0 +1,31 @@
+"""Tests for LongBench v2 dataset configs."""
+
+import ast
+from pathlib import Path
+
+
+def _longbenchv2_prompt():
+    repo_root = Path(__file__).resolve().parents[2]
+    config_path = (
+        repo_root /
+        'opencompass/configs/datasets/longbenchv2/longbenchv2_gen_75fbba.py'
+    )
+    tree = ast.parse(config_path.read_text(encoding='utf-8'))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for keyword in node.keywords:
+            if keyword.arg != 'prompt':
+                continue
+            if isinstance(keyword.value, ast.Constant):
+                prompt = keyword.value.value
+                if 'The correct answer is (insert answer here)' in prompt:
+                    return prompt
+    raise AssertionError('LongBench v2 prompt not found')
+
+
+def test_longbenchv2_prompt_has_complete_answer_format():
+    """Test LongBench v2 prompt keeps the official answer format."""
+    assert _longbenchv2_prompt().endswith(
+        'Format your response as follows: '
+        '"The correct answer is (insert answer here)".')


### PR DESCRIPTION
## Summary
- Restore the missing closing quote and period in the LongBench v2 answer-format instruction.
- Add a lightweight AST-based regression test for the prompt string.

Verified against the upstream LongBench prompt in THUDM/LongBench.

Fixes #2129

## Tests
- python3 -m pytest tests/datasets/test_longbenchv2_config.py -q
- python3 -m flake8 tests/datasets/test_longbenchv2_config.py
- python3 -m py_compile opencompass/configs/datasets/longbenchv2/longbenchv2_gen_75fbba.py tests/datasets/test_longbenchv2_config.py
- git diff --check