### PR TITLE
Handle None input in non-reasoning postprocessor

### DIFF
--- a/opencompass/utils/text_postprocessors.py
+++ b/opencompass/utils/text_postprocessors.py
@@ -247,7 +247,7 @@ def match_answer_pattern(response_text: str, answer_pattern: str):
 
 @TEXT_POSTPROCESSORS.register_module('extract-non-reasoning-content')
 def extract_non_reasoning_content(
-    text: str,
+    text: Optional[str],
     think_start_token: str = '<think>',
     think_end_token: str = '</think>',
 ) -> str:
@@ -275,6 +275,9 @@ def extract_non_reasoning_content(
         >>> extract_non_reasoning_content(text)
         'Start End'
     """
+    if text is None:
+        return ''
+        
     # If text contains only end token, split by end token and take the last part
     if think_start_token not in text and think_end_token in text:
         return text.split(think_end_token)[-1].strip()

--- a/tests/utils/test_text_postprocessors.py
+++ b/tests/utils/test_text_postprocessors.py
@@ -72,6 +72,9 @@ class TestTextPostprocessors(unittest.TestCase):
                          'How are you?')
         text = 'Start<think>reasoning</think> End'
         self.assertEqual(tp.extract_non_reasoning_content(text), 'Start End')
+    
+    def test_extract_non_reasoning_content_with_none(self):
+        self.assertEqual(tp.extract_non_reasoning_content(None), '')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Motivation

`extract_non_reasoning_content` assumes that the prediction text is always a
string. When a model prediction is `None`, the postprocessor checks token
membership on `None` and raises:

```text
TypeError: argument of type 'NoneType' is not iterable
This can break evaluation when extract_non_reasoning_content is used as a
prediction postprocessor and one prediction is null.

Fixes #1964.

## Modification
Allow extract_non_reasoning_content to accept Optional[str].
Return an empty string when the input text is None.
Add a regression test for extract_non_reasoning_content(None).

## BC-breaking (Optional)

No backward-incompatible change is expected. The change only handles an
additional invalid/null prediction case and keeps the existing behavior for
normal string inputs.

##  Use cases (Optional)

This fixes evaluation pipelines that use:
pred_postprocessor=dict(type=extract_non_reasoning_content)

when a model or API returns a null prediction for one sample.

## Checklist
- [ ] Pre-commit was not run locally.
- [ ] Local tests were not run locally.
- [x] A regression test for `None` input has been added.