### PR TITLE
[Dataset] Add ArxivRollBench

### DIFF
--- a/dataset-index.yml
+++ b/dataset-index.yml
@@ -359,6 +359,12 @@
     paper: https://arcprize.org/guide#private
     configpath: opencompass/configs/datasets/ARC_Prize_Public_Evaluation/arc_prize_public_evaluation_gen.py
     configpath_llmjudge: ''
+- arxivrollbench:
+    name: ArxivRollBench
+    category: Reasoning / Robustness
+    paper: https://ojs.aaai.org/index.php/AAAI/article/view/41098
+    configpath: opencompass/configs/datasets/arxivrollbench/arxivrollbench_gen.py
+    configpath_llmjudge: ''
 - ax:
     name: SuperGLUE / AX
     category: Reasoning

--- a/opencompass/configs/datasets/arxivrollbench/arxivrollbench_gen.py
+++ b/opencompass/configs/datasets/arxivrollbench/arxivrollbench_gen.py
@@ -1,7 +1,7 @@
 from opencompass.datasets import HFDataset
 from opencompass.openicl.icl_evaluator import AccEvaluator
 from opencompass.openicl.icl_inferencer import GenInferencer
-from opencompass.openicl.icl_prompt_template import PromptTemplate
+from opencompass.openicl.icl_raw_prompt_template import RawPromptTemplate
 from opencompass.openicl.icl_retriever import ZeroRetriever
 
 _DOMAINS = [
@@ -17,29 +17,38 @@ _DOMAINS = [
 _RELEASES = ['2024b', '2025a', '2026a']
 _TASK_TYPES = ['s', 'c', 'p']
 
-_SC_PROMPT = """You are evaluating an ArxivRollBench sequencing or cloze task.
-Choose the correct option and answer only with Selection 1, Selection 2, Selection 3, or Selection 4.
-
+_S_PROMPT = """## Instruction:
+ Given a **shuffled text** composed of sentences A, B, and C, your task is to select the correct order from four available selections. Avoid providing any additional information (such as explanations of your choice) or restating the sentences in your answer. Simply provide your selection: Selection 1, Selection 2, Selection 3, or Selection 4.
+## Shuffled text:
 {shuffled_text}
-
-Selection 1: {A}
-Selection 2: {B}
-Selection 3: {C}
-Selection 4: {D}
-
+## Choice:
+**Selection 1** {A}
+**Selection 2** {B}
+**Selection 3** {C}
+**Selection 4** {D}
 Answer:"""
 
-_P_PROMPT = """You are evaluating an ArxivRollBench prediction task.
-Choose the correct option and answer only with A, B, C, or D.
+_C_PROMPT = """## Instruction:
+ Given a **masked paragraph** with three masked sentences marked as '<|MaskedSentence|>' and candidate sentences labeled A, B, and C, your task is to fill in the correct sentences to the masked positions by selecting the appropriate answers from four provided selections. Avoid providing any additional information (such as explanations of your choice) or restating the sentences in your answer. Simply provide your selection: Selection 1, Selection 2, Selection 3, or Selection 4.
+## Masked paragraph:
+{text_with_holes}
+## {text_candidates}
+ ## Choice:
+**Selection 1** {A}
+**Selection 2** {B}
+**Selection 3** {C}
+**Selection 4** {D}
+Answer:"""
 
-Context:
+_P_PROMPT = """## Instruction:
+ Given a context, and four choices marked as A, B, C, and D, your task is to select the correct text which is the next sequence of the provided context. Avoid providing any additional information (such as explanations of your choice) or restating the choice in your answer. Simply provide one of the four letters: A, B, C, or D.
+## Context:
 {context}
-
-A. {A}
-B. {B}
-C. {C}
-D. {D}
-
+## Choice:
+**A** {A}
+**B** {B}
+**C** {C}
+**D** {D}
 Answer:"""
 
 
@@ -52,9 +61,17 @@ def _dataset_path(release, hf_domain, task_type, compact=True):
 
 
 def _reader_cfg(task_type):
-    if task_type in ['s', 'c']:
+    if task_type == 's':
         return dict(
             input_columns=['shuffled_text', 'A', 'B', 'C', 'D'],
+            output_column='label',
+            train_split='train',
+            test_split='train',
+        )
+    if task_type == 'c':
+        return dict(
+            input_columns=['text_with_holes', 'text_candidates', 'A', 'B',
+                           'C', 'D'],
             output_column='label',
             train_split='train',
             test_split='train',
@@ -68,14 +85,16 @@ def _reader_cfg(task_type):
 
 
 def _infer_cfg(task_type):
-    prompt = _SC_PROMPT if task_type in ['s', 'c'] else _P_PROMPT
+    prompt = dict(s=_S_PROMPT, c=_C_PROMPT, p=_P_PROMPT)[task_type]
     return dict(
         prompt_template=dict(
-            type=PromptTemplate,
-            template=dict(round=[dict(role='HUMAN', prompt=prompt)]),
+            type=RawPromptTemplate,
+            messages=[
+                dict(role='user', content=prompt),
+            ],
         ),
         retriever=dict(type=ZeroRetriever),
-        inferencer=dict(type=GenInferencer, max_out_len=50),
+        inferencer=dict(type=GenInferencer),
     )
 
 

--- a/opencompass/configs/datasets/arxivrollbench/arxivrollbench_gen.py
+++ b/opencompass/configs/datasets/arxivrollbench/arxivrollbench_gen.py
@@ -1,0 +1,115 @@
+from opencompass.datasets import HFDataset
+from opencompass.openicl.icl_evaluator import AccEvaluator
+from opencompass.openicl.icl_inferencer import GenInferencer
+from opencompass.openicl.icl_prompt_template import PromptTemplate
+from opencompass.openicl.icl_retriever import ZeroRetriever
+
+_DOMAINS = [
+    ('cs', 'cs'),
+    ('q_fin', 'q-fin'),
+    ('math', 'math'),
+    ('physics', 'physics'),
+    ('stat', 'stat'),
+    ('q_bio', 'q-bio'),
+    ('econ', 'econ'),
+    ('eess', 'eess'),
+]
+_RELEASES = ['2024b', '2025a', '2026a']
+_TASK_TYPES = ['s', 'c', 'p']
+
+_SC_PROMPT = """You are evaluating an ArxivRollBench sequencing or cloze task.
+Choose the correct option and answer only with Selection 1, Selection 2, Selection 3, or Selection 4.
+
+{shuffled_text}
+
+Selection 1: {A}
+Selection 2: {B}
+Selection 3: {C}
+Selection 4: {D}
+
+Answer:"""
+
+_P_PROMPT = """You are evaluating an ArxivRollBench prediction task.
+Choose the correct option and answer only with A, B, C, or D.
+
+Context:
+{context}
+
+A. {A}
+B. {B}
+C. {C}
+D. {D}
+
+Answer:"""
+
+
+def _dataset_path(release, hf_domain, task_type, compact=True):
+    suffix = '-50' if compact else ''
+    if release == '2024b':
+        return f'liangzid/robench2024b_all_set{hf_domain}SCP-{task_type}{suffix}'
+    return (f'liangzid/robench{release}_test_all_category_set'
+            f'{hf_domain}SCP-{task_type}{suffix}')
+
+
+def _reader_cfg(task_type):
+    if task_type in ['s', 'c']:
+        return dict(
+            input_columns=['shuffled_text', 'A', 'B', 'C', 'D'],
+            output_column='label',
+            train_split='train',
+            test_split='train',
+        )
+    return dict(
+        input_columns=['context', 'A', 'B', 'C', 'D'],
+        output_column='label',
+        train_split='train',
+        test_split='train',
+    )
+
+
+def _infer_cfg(task_type):
+    prompt = _SC_PROMPT if task_type in ['s', 'c'] else _P_PROMPT
+    return dict(
+        prompt_template=dict(
+            type=PromptTemplate,
+            template=dict(round=[dict(role='HUMAN', prompt=prompt)]),
+        ),
+        retriever=dict(type=ZeroRetriever),
+        inferencer=dict(type=GenInferencer, max_out_len=50),
+    )
+
+
+def _eval_cfg(task_type):
+    postprocessor = ('arxivrollbench_selection_postprocess' if task_type
+                     in ['s', 'c'] else 'arxivrollbench_choice_postprocess')
+    return dict(
+        evaluator=dict(type=AccEvaluator),
+        pred_postprocessor=dict(type=postprocessor),
+    )
+
+
+def _build_datasets(compact=True):
+    datasets = []
+    for release in _RELEASES:
+        for domain, hf_domain in _DOMAINS:
+            for task_type in _TASK_TYPES:
+                suffix = '' if compact else '-full'
+                datasets.append(
+                    dict(
+                        abbr=(f'arxivrollbench-{release}-{domain}-'
+                              f'{task_type}{suffix}'),
+                        type=HFDataset,
+                        path=_dataset_path(release, hf_domain, task_type,
+                                           compact),
+                        reader_cfg=_reader_cfg(task_type),
+                        infer_cfg=_infer_cfg(task_type),
+                        eval_cfg=_eval_cfg(task_type),
+                    ))
+    return datasets
+
+
+# Default ArxivRollBench configuration: compact 50-sample splits.
+arxivrollbench_datasets = _build_datasets(compact=True)
+
+# Full public splits are also provided for complete benchmark runs.
+arxivrollbench_full_datasets = _build_datasets(compact=False)

--- a/opencompass/datasets/__init__.py
+++ b/opencompass/datasets/__init__.py
@@ -7,6 +7,7 @@ from .anthropics_evals import *  # noqa: F401, F403
 from .apps import *  # noqa: F401, F403
 from .arc import *  # noqa: F401, F403
 from .arc_prize_public_evaluation import *  # noqa: F401, F403
+from .arxivrollbench import *  # noqa: F401, F403
 from .ax import *  # noqa: F401, F403
 from .babilong import *  # noqa: F401, F403
 from .bbeh import *  # noqa: F401, F403

--- a/opencompass/datasets/arxivrollbench.py
+++ b/opencompass/datasets/arxivrollbench.py
@@ -1,0 +1,30 @@
+import re
+
+from opencompass.registry import TEXT_POSTPROCESSORS
+
+
+@TEXT_POSTPROCESSORS.register_module()
+def arxivrollbench_selection_postprocess(text: str) -> str:
+    """Extract an ArxivRollBench S/C answer in ``Selection N`` format."""
+    if text is None:
+        return ''
+    text = str(text).strip()
+    match = re.search(r'\bselection\s*([1-4])\b', text, re.IGNORECASE)
+    if match:
+        return f'Selection {match.group(1)}'
+    match = re.search(r'\b([1-4])\b', text)
+    if match:
+        return f'Selection {match.group(1)}'
+    return text
+
+
+@TEXT_POSTPROCESSORS.register_module()
+def arxivrollbench_choice_postprocess(text: str) -> str:
+    """Extract an ArxivRollBench P-task answer in A/B/C/D format."""
+    if text is None:
+        return ''
+    text = str(text).strip()
+    match = re.search(r'\b([ABCD])\b', text, re.IGNORECASE)
+    if match:
+        return match.group(1).upper()
+    return text


### PR DESCRIPTION
## Summary

This PR adds ArxivRollBench to OpenCompass as a generative exact-match benchmark.

ArxivRollBench is a private-to-public rolling benchmark built from recent arXiv papers. It evaluates whether LLMs can reason over fresh scholarly text through three task formats: sequencing, cloze, and next-fragment prediction. Its key principle is time-aware evaluation: benchmark snapshots are created from papers that were private or newly released at the time of construction, then later become public so the community can reproduce and compare results. This helps measure model generalization on recent scientific content while reducing the overestimation risk caused by benchmark contamination.

The benchmark paper has been accepted by AAAI 2026:
https://ojs.aaai.org/index.php/AAAI/article/view/41098

The public Hugging Face datasets are available under:
https://huggingface.co/liangzid

## Changes

- Adds `opencompass/configs/datasets/arxivrollbench/arxivrollbench_gen.py`.
- Provides default compact `-50` splits for ArxivRollBench 2024b, 2025a, and 2026a across eight arXiv domains and three SCP task formats.
- Provides full split configs through `arxivrollbench_full_datasets`.
- Adds registered answer postprocessors for `Selection 1`-`Selection 4` and `A`-`D` answers.
- Adds ArxivRollBench to `dataset-index.yml`.

## Why This Benchmark Is Useful For OpenCompass

OpenCompass already covers many static knowledge, reasoning, and domain benchmarks. ArxivRollBench complements them by focusing on recent scientific papers and rolling release snapshots. This gives users a lightweight way to test models on time-sensitive scholarly reasoning tasks, while keeping the default `-50` split cost-controlled for API and large-model evaluation. The full split remains available for complete benchmark runs.

## Validation

- `python -m compileall -q opencompass/datasets/arxivrollbench.py opencompass/configs/datasets/arxivrollbench/arxivrollbench_gen.py`
- YAML parse check for `dataset-index.yml`.
- Config import check: generated 72 compact datasets and 72 full datasets.
- Hugging Face smoke load checks for compact and full ArxivRollBench dataset paths.
- OpenCompass `build_dataset_from_cfg` smoke check for one configured dataset.
- `AccEvaluator` smoke check for both registered answer postprocessors.
- `git diff --check`
