### PR TITLE
[Fix] Handle max_out_len=None in HuggingFace generation

### DIFF
--- a/opencompass/models/huggingface.py
+++ b/opencompass/models/huggingface.py
@@ -238,6 +238,16 @@ class HuggingFace(BaseModel):
         """
         generation_kwargs = kwargs.copy()
         generation_kwargs.update(self.generation_kwargs)
+
+        if max_out_len is None:
+            max_out_len = generation_kwargs.pop('max_new_tokens', None)
+        else:
+            generation_kwargs.pop('max_new_tokens', None)
+
+        if max_out_len is None:
+            raise ValueError(
+                '`max_out_len` is required when `max_new_tokens` is not '
+                'set in `generation_kwargs`.')
         if self.batch_padding and len(inputs) > 1:
             return self._batch_generate(inputs=inputs,
                                         max_out_len=max_out_len,
@@ -729,11 +739,12 @@ class HuggingFaceChatGLM3(HuggingFace):
         # used to compensate for #tokens occupied by sth like system prompt
         self.num_extra_tokens = num_extra_tokens
 
-    def generate(self,
-                 inputs: List[PromptType],
-                 max_out_len: int = 512,
-                 skip_overlength=False,
-                 **kwargs) -> str:
+        def generate(self,
+                     inputs: List[str],
+                     max_out_len: Optional[int] = None,
+                     min_out_len: Optional[int] = None,
+                     stopping_criteria: List[str] = [],
+                     **kwargs) -> List[str]:
         """Generate response from input prompt.
 
         Args:

--- a/opencompass/models/huggingface.py
+++ b/opencompass/models/huggingface.py
@@ -739,12 +739,11 @@ class HuggingFaceChatGLM3(HuggingFace):
         # used to compensate for #tokens occupied by sth like system prompt
         self.num_extra_tokens = num_extra_tokens
 
-        def generate(self,
-                     inputs: List[str],
-                     max_out_len: Optional[int] = None,
-                     min_out_len: Optional[int] = None,
-                     stopping_criteria: List[str] = [],
-                     **kwargs) -> List[str]:
+    def generate(self,
+                 inputs: List[PromptType],
+                 max_out_len: int = 512,
+                 skip_overlength=False,
+                 **kwargs) -> str:
         """Generate response from input prompt.
 
         Args:

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -86,6 +86,47 @@ class TestHuggingFace(unittest.TestCase):
 
     @patch('transformers.AutoTokenizer')
     @patch('transformers.AutoModelForCausalLM')
+    @patch('opencompass.models.huggingface.torch')
+    def test_generate_uses_max_new_tokens_when_max_out_len_is_none(
+            self, mock_torch, mock_model_class, mock_tokenizer_class):
+        """Test max_new_tokens is used when max_out_len is None."""
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.pad_token_id = 0
+        mock_tokenizer.eos_token = None
+        mock_tokenizer.return_value = {'input_ids': [[1, 2, 3]]}
+        mock_tokenizer.batch_decode.return_value = ['Generated response']
+        mock_tokenizer_class.from_pretrained.return_value = mock_tokenizer
+
+        mock_input_tensor = MagicMock()
+        mock_input_tensor.shape = [1, 3]
+        mock_torch.tensor.return_value = mock_input_tensor
+
+        mock_model = MagicMock()
+        mock_model.device = 'cpu'
+        mock_output = MagicMock()
+        mock_output.__getitem__.return_value = mock_output
+        mock_model.generate.return_value = mock_output
+        mock_model_class.from_pretrained.return_value = mock_model
+
+        model = HuggingFace(
+            path='test/model/path',
+            max_seq_len=2048,
+            model_kwargs=dict(device_map='cpu'),
+            generation_kwargs=dict(max_new_tokens=32, temperature=0.0),
+        )
+
+        results = model.generate(['Hello'], max_out_len=None)
+
+        self.assertEqual(results, ['Generated response'])
+        mock_tokenizer.assert_called_with(
+            ['Hello'], padding=False, truncation=True, max_length=2016)
+
+        generate_kwargs = mock_model.generate.call_args.kwargs
+        self.assertEqual(generate_kwargs['max_new_tokens'], 32)
+        self.assertEqual(generate_kwargs['temperature'], 0.0)
+
+    @patch('transformers.AutoTokenizer')
+    @patch('transformers.AutoModelForCausalLM')
     def test_get_token_len(self, mock_model_class, mock_tokenizer_class):
         """Test get_token_len method."""
         mock_tokenizer = MagicMock()

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -118,12 +118,35 @@ class TestHuggingFace(unittest.TestCase):
         results = model.generate(['Hello'], max_out_len=None)
 
         self.assertEqual(results, ['Generated response'])
-        mock_tokenizer.assert_called_with(
-            ['Hello'], padding=False, truncation=True, max_length=2016)
+        mock_tokenizer.assert_called_with(['Hello'],
+                                          truncation=True,
+                                          max_length=2016)
 
         generate_kwargs = mock_model.generate.call_args.kwargs
         self.assertEqual(generate_kwargs['max_new_tokens'], 32)
         self.assertEqual(generate_kwargs['temperature'], 0.0)
+
+    @patch('transformers.AutoTokenizer')
+    @patch('transformers.AutoModelForCausalLM')
+    def test_generate_requires_length_when_max_out_len_is_none(
+            self, mock_model_class, mock_tokenizer_class):
+        """Test a clear error is raised when no output length is provided."""
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.pad_token_id = 0
+        mock_tokenizer_class.from_pretrained.return_value = mock_tokenizer
+
+        mock_model = MagicMock()
+        mock_model.device = 'cpu'
+        mock_model_class.from_pretrained.return_value = mock_model
+
+        model = HuggingFace(
+            path='test/model/path',
+            max_seq_len=2048,
+            model_kwargs=dict(device_map='cpu'),
+        )
+
+        with self.assertRaisesRegex(ValueError, '`max_out_len` is required'):
+            model.generate(['Hello'], max_out_len=None)
 
     @patch('transformers.AutoTokenizer')
     @patch('transformers.AutoModelForCausalLM')


### PR DESCRIPTION
Fixes #2270.

## Motivation

When `HuggingFace.generate()` is called with `max_out_len=None`, `_single_generate()` currently computes:

python
self.max_seq_len - max_out_len

This raises:

TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'

This can happen when the generation length is provided through generation_kwargs, for example:

generation_kwargs=dict(max_new_tokens=32)

##  Modification
Allow HuggingFace.generate() to accept max_out_len=None.
If max_out_len is None, use generation_kwargs["max_new_tokens"] as the effective output length.
Remove max_new_tokens from generation_kwargs before calling HuggingFace model.generate() to avoid passing duplicate keyword arguments.
Raise a clearer ValueError if neither max_out_len nor max_new_tokens is provided.
Add a regression test for the max_out_len=None case.

## BC-breaking

No backward-incompatible change is expected. Existing calls with an explicit max_out_len keep the same behaviour.

##  Validation
python -m pytest tests/models/test_huggingface.py -q
pre-commit run --files opencompass/models/huggingface.py tests/models/test_huggingface.py