### PR TITLE
add parameter "--no-progress" to not print detail logs when analyze repeat, by default behavior is print

### DIFF
--- a/tools/analyze_repeat.py
+++ b/tools/analyze_repeat.py
@@ -30,6 +30,9 @@ def parse_args():
                         type=str,
                         help='Think tag to split reasoning and content.')
     parser.add_argument('--out', type=Path, help='output file path')
+    parser.add_argument('--no-progress',
+                        action='store_true',
+                        help='Disable benchmark progress bars.')
     args = parser.parse_args()
     return args
 
@@ -140,7 +143,7 @@ def main():
         print(f'\n[{benchmark}] ({len(records)} samples)')
 
         stats = _analyze_benchmark(records, {model_abbr: tokenizer},
-                                   show_progress=True,
+                                   show_progress=not args.no_progress,
                                    batch_size=args.batch_size,
                                    think_tag=args.think_tag)
         benchmark_stats[benchmark] = stats


### PR DESCRIPTION
## Motivation

Add switcher to control not print too much details log when run analyze_repeat.py
By default print unless pass parameter `--no-progress`

Before: print thousands lines of details progress log like:
<img width="869" height="1119" alt="img_v3_0212b_54549b3b-d910-46f5-84a4-62a96d0927fg" src="https://github.com/user-attachments/assets/0ff5a231-90b9-4f49-9b64-defd3120c87d" />

After: only print the red block content
<img width="2274" height="916" alt="img_v3_0212b_d231c955-b819-4b88-9762-d1aaa761989g" src="https://github.com/user-attachments/assets/4143374d-f019-4e31-b5f6-9d22ab66437f" />


