### PR TITLE
[Fix] Extract the final answer in GPQA simple-eval predictions

### DIFF
--- a/opencompass/datasets/gpqa.py
+++ b/opencompass/datasets/gpqa.py
@@ -108,8 +108,14 @@ class GPQASimpleEvalDataset(BaseDataset):
 
 @TEXT_POSTPROCESSORS.register_module()
 def GPQA_Simple_Eval_postprocess(text: str) -> str:
-    ANSWER_PATTERN = r'(?i)ANSWER\s*:\s*([A-D])'
-    match = re.search(ANSWER_PATTERN, text)
-    if match:
-        return match.group(1)
+    """Extract the final explicit answer from GPQA simple-eval output.
+
+    The prompt requires the answer to appear on the last line, so we keep the
+    last valid `ANSWER: <letter>` match instead of the first one.
+    """
+
+    answer_pattern = r'(?i)ANSWER\s*:\s*([A-D])'
+    matches = re.findall(answer_pattern, text)
+    if matches:
+        return matches[-1]
     return None

--- a/tests/datasets/test_gpqa.py
+++ b/tests/datasets/test_gpqa.py
@@ -1,0 +1,106 @@
+"""Regression tests for GPQA simple-eval post-processing."""
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GPQA_MODULE_PATH = ROOT / 'opencompass' / 'datasets' / 'gpqa.py'
+
+
+class DummyRegistry:
+
+    def register_module(self, *args, **kwargs):
+        def decorator(obj):
+            return obj
+
+        if args and callable(args[0]) and not kwargs:
+            return args[0]
+        return decorator
+
+
+def load_gpqa_postprocess():
+    """Load the GPQA module with lightweight stubs for optional deps."""
+
+    opencompass_pkg = types.ModuleType('opencompass')
+    opencompass_pkg.__path__ = [str(ROOT / 'opencompass')]
+
+    datasets_pkg = types.ModuleType('opencompass.datasets')
+    datasets_pkg.__path__ = [str(ROOT / 'opencompass' / 'datasets')]
+
+    base_mod = types.ModuleType('opencompass.datasets.base')
+
+    class BaseDataset:  # noqa: D401
+        pass
+
+    base_mod.BaseDataset = BaseDataset
+
+    registry_mod = types.ModuleType('opencompass.registry')
+    registry_mod.LOAD_DATASET = DummyRegistry()
+    registry_mod.TEXT_POSTPROCESSORS = DummyRegistry()
+
+    openicl_mod = types.ModuleType('opencompass.openicl')
+
+    class BaseEvaluator:  # noqa: D401
+        pass
+
+    openicl_mod.BaseEvaluator = BaseEvaluator
+
+    utils_mod = types.ModuleType('opencompass.utils')
+    utils_mod.get_data_path = lambda path, local_mode=True: path
+
+    datasets_mod = types.ModuleType('datasets')
+
+    class Dataset:  # noqa: D401
+        @classmethod
+        def from_list(cls, data):
+            return data
+
+    datasets_mod.Dataset = Dataset
+
+    sys.modules['opencompass'] = opencompass_pkg
+    sys.modules['opencompass.datasets'] = datasets_pkg
+    sys.modules['opencompass.datasets.base'] = base_mod
+    sys.modules['opencompass.registry'] = registry_mod
+    sys.modules['opencompass.openicl'] = openicl_mod
+    sys.modules['opencompass.utils'] = utils_mod
+    sys.modules['datasets'] = datasets_mod
+
+    spec = importlib.util.spec_from_file_location('opencompass.datasets.gpqa',
+                                                  GPQA_MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.GPQA_Simple_Eval_postprocess
+
+
+GPQA_Simple_Eval_postprocess = load_gpqa_postprocess()
+
+
+class TestGPQASimpleEvalPostprocess(unittest.TestCase):
+
+    def test_returns_the_last_answer_match(self):
+        text = (
+            'Reasoning step 1.\n'
+            'ANSWER: C\n'
+            'Self-correction after review.\n'
+            'ANSWER: B\n')
+
+        self.assertEqual(GPQA_Simple_Eval_postprocess(text), 'B')
+
+    def test_accepts_case_and_spacing_variants(self):
+        text = 'analysis complete.\nAnSwEr   :   D'
+
+        self.assertEqual(GPQA_Simple_Eval_postprocess(text), 'D')
+
+    def test_returns_none_when_no_answer_match_exists(self):
+        text = 'Reasoning only, no final answer token is present.'
+
+        self.assertIsNone(GPQA_Simple_Eval_postprocess(text))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# [Fix] Extract the final answer in GPQA simple-eval predictions

## Motivation

GPQA simple-eval prompts require the model to place the final answer on the last line in the form `ANSWER: <LETTER>`. In practice, some model outputs contain multiple `ANSWER:` tokens because the model reasons aloud, drafts an intermediate guess, and then self-corrects. The previous postprocessor used the first regex match, so it could pick an earlier intermediate answer instead of the final one and undercount accuracy.

## Modification

- Update `GPQA_Simple_Eval_postprocess` to collect all `ANSWER: [A-D]` matches and return the last match.
- Keep the existing matching behavior unchanged for:
  - case-insensitive `ANSWER`
  - optional whitespace around `:`
  - valid answer letters restricted to `A-D`
- Add regression tests that cover:
  - a single match
  - multiple matches where the last one should win
  - case and whitespace variants
  - no-match behavior
- Remove the temporary GPQA README note so the branch only contains the actual code fix and regression coverage.

## BC-breaking (Optional)

No backward-compatible API break is introduced. This is a behavior fix in post-processing for GPQA simple-eval predictions.

## Use cases (Optional)

This affects GPQA simple-eval evaluation, especially for model responses that include:

- a draft answer followed by a corrected final answer
- chain-of-thought outputs with repeated `ANSWER:` tokens
- prompts that explicitly instruct the model to put the answer on the last line

## Technical Analysis

The bug comes from the mismatch between the prompt contract and the extraction strategy:

- The prompt instructs the model to put the answer in the final line.
- The old implementation used `re.search`, which stops at the first match.
- If the model emits multiple `ANSWER:` tokens, the first one is often an intermediate guess, not the final answer.

The fix uses `re.findall(...)[-1]`, which preserves the existing regex constraint while selecting the last valid answer token. This makes the evaluator align with the prompt semantics and avoids false negatives caused by intermediate self-corrections.

## Test Plan

- `python tests/datasets/test_gpqa.py`
- `python -m unittest tests.datasets.test_gpqa`

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
