### PR TITLE
Add robust HumanEval postprocess for chat outputs

### DIFF
--- a/opencompass/datasets/humaneval.py
+++ b/opencompass/datasets/humaneval.py
@@ -191,6 +191,55 @@ def humaneval_postprocess_v3(text: str) -> str:
         text = blocks[-1]
     return text.lstrip()
 
+def humaneval_chat_postprocess(text: str) -> str:
+    """Postprocess chat model outputs for HumanEval.
+
+    Some chat/API models return reasoning before the final code, or emit an
+    opening Markdown code fence that is never closed because the generation is
+    truncated. The regular ``humaneval_postprocess_v2`` intentionally keeps
+    non-fenced text unchanged; this variant first tries to recover a Python
+    code block or a clear top-level Python snippet from chatty responses.
+    """
+    code = _extract_first_code_fence(text)
+    if code is not None:
+        return _trim_to_compilable_prefix(code).lstrip()
+
+    code = _extract_python_snippet(text)
+    if code is not None:
+        return _trim_to_compilable_prefix(code).lstrip()
+
+    return text.lstrip()
+
+def _extract_first_code_fence(text: str):
+    match = re.search(r'```\w*\n(.*?)(?:```|$)', text, re.DOTALL)
+    if match is None:
+        return None
+    return match.group(1)
+
+def _extract_python_snippet(text: str):
+    pattern = re.compile(
+        r'(?m)^\s*(?:from\s+\S+\s+import\s+|import\s+|def\s+|class\s+|@\w)')
+    match = pattern.search(text)
+    if match is None:
+        return None
+    return text[match.start():]
+
+def _trim_to_compilable_prefix(text: str) -> str:
+    stripped = text.lstrip()
+    if not re.match(r'^(?:from\s+\S+\s+import\s+|import\s+|def\s+|class\s+|@\w)',
+                    stripped):
+        return text
+
+    lines = text.splitlines()
+    for end in range(len(lines), 0, -1):
+        candidate = '\n'.join(lines[:end]) + '\n'
+        try:
+            compile(candidate, '<humaneval_postprocess>', 'exec')
+        except SyntaxError:
+            continue
+        return candidate.rstrip() + '\n'
+    return text
+
 def humaneval_internal_v2_postprocess(text: str):
     if text.startswith('   ') and not text.startswith('    '):
         text = ' ' + text

--- a/tests/datasets/test_humaneval.py
+++ b/tests/datasets/test_humaneval.py
@@ -1,6 +1,7 @@
 import unittest
 
-from opencompass.datasets.humaneval import (humaneval_postprocess_v2,
+from opencompass.datasets.humaneval import (humaneval_chat_postprocess,
+                                            humaneval_postprocess_v2,
                                             humaneval_postprocess_v3)
 
 
@@ -71,6 +72,52 @@ class TestHumanevalPostprocess(unittest.TestCase):
         expected = 'value = x - int(x)\n    return value\n'
         self.assertEqual(humaneval_postprocess_v2(raw), expected)
         self.assertEqual(humaneval_postprocess_v3(raw), expected)
+
+    def test_chat_extracts_unclosed_code_block(self):
+        raw = '\n'.join([
+            'Here is the implementation:',
+            '```python',
+            'def truncate_number(number: float) -> float:',
+            '    return number - int(number)',
+        ])
+
+        self.assertEqual(
+            humaneval_chat_postprocess(raw),
+            'def truncate_number(number: float) -> float:\n'
+            '    return number - int(number)\n')
+
+    def test_chat_extracts_code_after_reasoning(self):
+        raw = '\n'.join([
+            'We need to subtract the integer part.',
+            'The final answer is:',
+            'def truncate_number(number: float) -> float:',
+            '    return number - int(number)',
+        ])
+
+        self.assertEqual(
+            humaneval_chat_postprocess(raw),
+            'def truncate_number(number: float) -> float:\n'
+            '    return number - int(number)\n')
+
+    def test_chat_trims_trailing_explanation(self):
+        raw = '\n'.join([
+            'Here is the implementation:',
+            'def truncate_number(number: float) -> float:',
+            '    return number - int(number)',
+            '',
+            'This solves the task.',
+        ])
+
+        self.assertEqual(
+            humaneval_chat_postprocess(raw),
+            'def truncate_number(number: float) -> float:\n'
+            '    return number - int(number)\n')
+
+    def test_chat_keeps_plain_function_body(self):
+        raw = '    return x - int(x)\n'
+
+        self.assertEqual(humaneval_chat_postprocess(raw),
+                         'return x - int(x)\n')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Motivation

The current HumanEval postprocess mainly extracts closed Markdown code blocks from model outputs. This works for models that return clean fenced code, but it is less robust for chat/API models that may include reasoning before the final code or produce an opening code fence that is not closed because the generation is truncated.

In these cases, the evaluator may receive natural-language text instead of the intended Python solution, which can cause `SyntaxError` failures due to output formatting rather than the generated solution itself.

This PR aims to make HumanEval postprocessing more robust for chat-style model outputs while keeping the existing postprocess behavior unchanged.

## Modification

This PR adds a new `humaneval_chat_postprocess` function.

The new postprocessor:

- extracts the first Markdown code block, including unclosed code fences;
- falls back to extracting a clear Python snippet starting with `from`, `import`, `def`, `class`, or a decorator;
- trims trailing non-code text by keeping the longest compilable Python prefix;
- does not modify the existing `humaneval_postprocess_v2` or `humaneval_postprocess_v3` behavior.

Unit tests are added for:

- unclosed Markdown code fences;
- Python code appearing after natural-language reasoning;
- trailing explanation after code;
- existing plain function-body behavior.

## BC-breaking (Optional)

No backward compatibility breaking change is introduced.

The existing `humaneval_postprocess_v2` and `humaneval_postprocess_v3` functions are unchanged. The new `humaneval_chat_postprocess` function is opt-in and only affects users who explicitly configure it.

## Use cases (Optional)

This postprocessor can be used when evaluating chat/API models on HumanEval, especially when the model output may contain reasoning text before the final Python code or an unclosed Markdown code fence.

Example use case:

    humaneval_eval_cfg = dict(
        evaluator=dict(type=HumanEvalEvaluator),
        pred_role='BOT',
        k=[1, 10, 100],
        pred_postprocessor=dict(type=humaneval_chat_postprocess),
    )

The postprocessor only recovers code already produced by the model. It does not repair invalid code, synthesize missing function bodies, or modify model logic.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.