### PR TITLE
fix(evaluator): guard IndexError on truncated judge choice (JudgeEvaluator/RMBEvaluator)

### DIFF
--- a/opencompass/openicl/icl_evaluator/icl_judge_evaluator.py
+++ b/opencompass/openicl/icl_evaluator/icl_judge_evaluator.py
@@ -16,8 +16,10 @@ class JudgeEvaluator(BaseEvaluator):
         count = 0
         details = []
         for prediction, reference in zip(predictions, references):
-            choice = prediction.split("\"Choice\": \"Model ")[-1][0] if len(
-                prediction) != 0 else None
+            _choice_tail = (
+                prediction.split("\"Choice\": \"Model ")[-1]
+                if len(prediction) != 0 else '')
+            choice = _choice_tail[0] if _choice_tail else None
             gold_winner = reference.get('winner', '')
             detail = {
                 'pred': prediction,
@@ -76,8 +78,10 @@ class RMBEvaluator(BaseEvaluator):
         pair_harm_list = []
 
         for prediction, reference in zip(predictions, references):
-            choice = prediction.split("\"Choice\": \"Model ")[-1][0] if len(
-                prediction) != 0 else None
+            _choice_tail = (
+                prediction.split("\"Choice\": \"Model ")[-1]
+                if len(prediction) != 0 else '')
+            choice = _choice_tail[0] if _choice_tail else None
             gold_winner = reference.get('winner', '')
             subset = reference.get('subset', '')
             goal = reference.get('goal', '')

--- a/tests/openicl/test_icl_judge_evaluator.py
+++ b/tests/openicl/test_icl_judge_evaluator.py
@@ -1,0 +1,27 @@
+# flake8: noqa
+from opencompass.openicl.icl_evaluator.icl_judge_evaluator import JudgeEvaluator
+
+
+def test_judge_evaluator_truncated_choice_does_not_crash():
+    """A judge output truncated right at the ``"Choice": "Model `` marker (before
+    the model letter) must not raise IndexError; the missing choice should simply
+    not match the gold winner."""
+    evaluator = JudgeEvaluator()
+    predictions = ['{"Choice": "Model ']  # truncated before the letter
+    references = [{'winner': 'A'}]
+
+    result = evaluator.score(predictions, references)
+
+    assert result['accuracy'] == 0.0
+    assert result['details'][0]['correct'] is False
+
+
+def test_judge_evaluator_scores_normal_choice():
+    evaluator = JudgeEvaluator()
+    predictions = ['Reasoning... {"Choice": "Model A"}']
+    references = [{'winner': 'A'}]
+
+    result = evaluator.score(predictions, references)
+
+    assert result['accuracy'] == 100.0
+    assert result['details'][0]['correct'] is True


### PR DESCRIPTION
### problem
`JudgeEvaluator.score` and `RMBEvaluator.score` extract the winning model letter with:
```python
choice = prediction.split("\"Choice\": \"Model ")[-1][0] if len(prediction) != 0 else None
```
the guard checks that `prediction` is non-empty, but the `[0]` indexes the **split tail**, which can be empty even when the prediction isn't - e.g. a judge response truncated right at the marker (`... "Choice": "Model ` with nothing after, common under `max_tokens` clipping). then `split(...)[-1]` is `""` and `""[0]` raises `IndexError`, crashing scoring for the whole batch.

### repro
```python
p = '{"Choice": "Model '            # truncated before the letter
p.split('"Choice": "Model ')[-1][0]  # IndexError: string index out of range
```

### fix
index the split tail only when it's non-empty (missing choice -> `None`, which simply doesn't match the gold winner). applied to both `JudgeEvaluator` and `RMBEvaluator`.

### test
added `tests/openicl/test_icl_judge_evaluator.py`: the truncated-marker case no longer crashes (scores 0.0), and a normal `"Choice": "Model A"` still scores correctly.
