### PR TITLE
[Fix] Handle tokenizers with read-only pad_token_id property

### DIFF
--- a/opencompass/models/huggingface.py
+++ b/opencompass/models/huggingface.py
@@ -144,7 +144,19 @@ class HuggingFace(BaseModel):
                 self.logger.warning(
                     'pad_token_id is not consistent with the tokenizer. Using '
                     f'{self.pad_token_id} as pad_token_id')
-            self.tokenizer.pad_token_id = self.pad_token_id
+            try:
+                self.tokenizer.pad_token_id = self.pad_token_id
+            except AttributeError:
+                # Some tokenizers (e.g. ChatGLM3's ChatGLMTokenizer)
+                # expose pad_token_id as a read-only @property without a
+                # setter. Fall back to the tokenizer's existing
+                # pad_token_id instead of crashing.
+                # See https://github.com/open-compass/opencompass/issues/725
+                self.logger.warning(
+                    f'Cannot set pad_token_id on '
+                    f'{type(self.tokenizer).__name__} (read-only property).'
+                    f' Falling back to the tokenizer default '
+                    f'pad_token_id {self.tokenizer.pad_token_id}.')
         elif self.tokenizer.pad_token_id is None:
             self.logger.warning('pad_token_id is not set for the tokenizer.')
             if self.tokenizer.eos_token is not None:

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -7,6 +7,20 @@ from unittest.mock import MagicMock, patch
 from opencompass.models.huggingface import HuggingFace
 
 
+class _ReadOnlyPadTokenizer:
+    """Mimic ChatGLM3's ChatGLMTokenizer whose ``pad_token_id`` is a
+    read-only ``@property`` without a setter. See issue #725.
+    """
+
+    vocab_size = 65024
+
+    @property
+    def pad_token_id(self):
+        # Returns a value different from what the user requested, so the
+        # "not consistent" warning branch in _load_tokenizer is exercised.
+        return 0
+
+
 class TestHuggingFace(unittest.TestCase):
     """Test cases for HuggingFace."""
 
@@ -308,6 +322,69 @@ class TestHuggingFace(unittest.TestCase):
 
             self.assertEqual(len(results), 1)
             self.assertIsInstance(results[0], (float, np.floating))
+
+    @patch('transformers.AutoTokenizer')
+    @patch('transformers.AutoModelForCausalLM')
+    def test_pad_token_id_read_only_property_issue_725(
+            self, mock_model_class, mock_tokenizer_class):
+        """Regression test for issue #725.
+
+        Some tokenizers (e.g. ChatGLM3's ``ChatGLMTokenizer``) expose
+        ``pad_token_id`` as a read-only ``@property`` without a setter.
+        Assigning to it previously raised
+        ``AttributeError: can't set attribute 'pad_token_id'`` during
+        ``_load_tokenizer``. The fix catches this and falls back to the
+        tokenizer's existing ``pad_token_id`` with a warning instead of
+        crashing model initialization.
+        """
+        mock_tokenizer = _ReadOnlyPadTokenizer()
+        mock_tokenizer_class.from_pretrained.return_value = mock_tokenizer
+        mock_model = MagicMock()
+        mock_model.device = 'cpu'
+        mock_model_class.from_pretrained.return_value = mock_model
+
+        # Before the fix this raised:
+        #   AttributeError: can't set attribute 'pad_token_id'
+        model = HuggingFace(
+            path='test/model/path',
+            max_seq_len=2048,
+            pad_token_id=151643,
+            model_kwargs=dict(device_map='cpu'),
+        )
+
+        # The user-requested value is preserved on the wrapper; the
+        # tokenizer's read-only value remains unchanged.
+        self.assertEqual(model.pad_token_id, 151643)
+        self.assertEqual(model.tokenizer.pad_token_id, 0)
+
+    @patch('transformers.AutoTokenizer')
+    @patch('transformers.AutoModelForCausalLM')
+    def test_pad_token_id_negative_with_read_only_property_issue_725(
+            self, mock_model_class, mock_tokenizer_class):
+        """Edge case for issue #725: negative pad_token_id with a
+        read-only property tokenizer.
+
+        A negative ``pad_token_id`` is normalized via
+        ``self.pad_token_id += tokenizer.vocab_size`` *before* the
+        assignment. The read-only-property guard must still catch the
+        subsequent ``AttributeError``.
+        """
+        mock_tokenizer = _ReadOnlyPadTokenizer()
+        mock_tokenizer_class.from_pretrained.return_value = mock_tokenizer
+        mock_model = MagicMock()
+        mock_model.device = 'cpu'
+        mock_model_class.from_pretrained.return_value = mock_model
+
+        model = HuggingFace(
+            path='test/model/path',
+            max_seq_len=2048,
+            pad_token_id=-1,
+            model_kwargs=dict(device_map='cpu'),
+        )
+
+        # -1 + vocab_size(65024) = 65023, preserved on the wrapper
+        self.assertEqual(model.pad_token_id, 65023)
+        self.assertEqual(model.tokenizer.pad_token_id, 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Motivation

Fixes #725.

When evaluating `THUDM/chatglm3-6b` (and any model whose tokenizer exposes
`pad_token_id` as a read-only `@property` without a setter), OpenCompass
crashes during model initialization:

```
File "opencompass/models/huggingface.py", line 147, in _load_tokenizer
    self.tokenizer.pad_token_id = self.pad_token_id
AttributeError: can't set attribute 'pad_token_id'
```

This was diagnosed by @acylam in the issue thread (2024-04-28): the
`ChatGLMTokenizer` loaded via `trust_remote_code=True` defines
`pad_token_id` as a `@property` without a setter, so the assignment raises
`AttributeError` and aborts model construction before inference ever
starts.

## Modification

In `opencompass/models/huggingface.py`, wrap the
`self.tokenizer.pad_token_id = self.pad_token_id` assignment in
`_load_tokenizer()` with a `try/except AttributeError`. If the tokenizer
rejects the assignment (read-only property), fall back to the tokenizer's
existing `pad_token_id` and emit a `logger.warning` so the behavior is
observable, not silent.

The user-supplied `pad_token_id` is still preserved on the `HuggingFace`
wrapper object — only the tokenizer's internal state falls back. This
matches the existing behavior one branch above, where the wrapper and
tokenizer are already allowed to diverge (the "pad_token_id is not
consistent with the tokenizer" warning).

```python
try:
    self.tokenizer.pad_token_id = self.pad_token_id
except AttributeError:
    # Some tokenizers (e.g. ChatGLM3's ChatGLMTokenizer)
    # expose pad_token_id as a read-only @property without a
    # setter. Fall back to the tokenizer's existing
    # pad_token_id instead of crashing.
    # See https://github.com/open-compass/opencompass/issues/725
    self.logger.warning(
        f'Cannot set pad_token_id on '
        f'{type(self.tokenizer).__name__} (read-only property).'
        f' Falling back to the tokenizer default '
        f'pad_token_id {self.tokenizer.pad_token_id}.')
```

Alternatives considered and rejected (name-based `isinstance` check,
property introspection, always-skip, raise clearer error) — the
`try/except` is the simplest EAFP form and handles any future tokenizer
with the same quirk, not just ChatGLM3.

## BC-breaking

None. The new code path only triggers for tokenizers that previously
crashed with `AttributeError`. All tokenizers with a writable
`pad_token_id` (the common case) take the same code path as before.

## Checklist

**Before PR:**

- [x] Pre-commit / linting tools run — `flake8` and `yapf` clean on the
      changed lines in `huggingface.py` (pre-existing yapf findings on
      lines 537/643 are unrelated to this change and left untouched to
      keep the diff minimal).
- [x] Bug fix is fully covered by unit tests; the case that causes the
      bug is added to the unit tests —
      `test_pad_token_id_read_only_property_issue_725`.
- [x] The modification is covered by complete unit tests — added an
      edge-case test
      `test_pad_token_id_negative_with_read_only_property_issue_725`
      for negative `pad_token_id` (normalized via `+= vocab_size`)
      with a read-only property tokenizer.
- [x] Documentation — added inline comment with issue link for future
      contributors; no docstring/tutorial changes needed for a
      single-line behavioral fix.

**After PR:**

- [ ] CLA signed at PR submission.

## Testing

```
$ python3 -m pytest tests/models/test_huggingface.py -v
...
tests/models/test_huggingface.py::TestHuggingFace::test_generate_basic PASSED [ 10%]
tests/models/test_huggingface.py::TestHuggingFace::test_generate_requires_length_when_max_out_len_is_none PASSED [ 20%]
tests/models/test_huggingface.py::TestHuggingFace::test_generate_uses_max_new_tokens_when_max_out_len_is_none PASSED [ 30%]
tests/models/test_huggingface.py::TestHuggingFace::test_generate_with_batch_padding PASSED [ 40%]
tests/models/test_huggingface.py::TestHuggingFace::test_generate_with_mid_mode PASSED [ 50%]
tests/models/test_huggingface.py::TestHuggingFace::test_get_ppl PASSED [ 60%]
tests/models/test_huggingface.py::TestHuggingFace::test_get_token_len PASSED [ 70%]
tests/models/test_huggingface.py::TestHuggingFace::test_initialization_basic PASSED [ 80%]
tests/models/test_huggingface.py::TestHuggingFace::test_pad_token_id_negative_with_read_only_property_issue_725 PASSED [ 90%]
tests/models/test_huggingface.py::TestHuggingFace::test_pad_token_id_read_only_property_issue_725 PASSED [100%]
============================== 10 passed in 3.82s ==============================
```

All 10 tests pass (8 existing + 2 new issue-#725 regression tests).

The new tests use a `_ReadOnlyPadTokenizer` helper that mimics
ChatGLM3's `ChatGLMTokenizer` property-without-setter behavior, so they
reproduce the bug without requiring a network fetch of the remote code.

---

*This PR was prepared with AI assistance (Claude) for code analysis and
test generation. All code has been reviewed and tested by the contributor.*

Co-authored-by: Claude <noreply@anthropic.com>
