### PR TITLE
ci: pin jlumbroso/free-disk-space to a full commit SHA

### DIFF
--- a/.github/workflows/pr-stage-check.yml
+++ b/.github/workflows/pr-stage-check.yml
@@ -23,7 +23,7 @@ jobs:
           - torch: 2.9.0
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: false
@@ -72,7 +72,7 @@ jobs:
         python-version: ['3.10']
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: false


### PR DESCRIPTION
### What
Pin `jlumbroso/free-disk-space@main` → `54081f1…` (both occurrences) in `pr-stage-check.yml`, keeping
the tag in a trailing comment.

### Why
`@main` is a moving reference — whatever it points to at run time runs in CI. Pinning to a full commit
SHA removes the "the action's `main` moved" risk (the class behind the 2025 `tj-actions/changed-files`
incident). This is defense-in-depth: the workflow runs on `pull_request`, so the exposure is smaller
than in a credentialed publish job, but a pinned SHA is still the recommended posture.

### Scope / safety
- Behaviour unchanged — the SHA is the current tip of the action's `main`. Signed-off.
- Renovate/Dependabot can still bump a SHA pin (the tag comment keeps it readable).

Per GitHub's guidance to [pin actions to a full-length commit SHA](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflow and the pinned SHA myself.</sub>
