### PR TITLE
fix: use last-match in generic LLM judge postprocess (verdict-injection defense)

### DIFF
--- a/opencompass/datasets/generic.py
+++ b/opencompass/datasets/generic.py
@@ -63,9 +63,13 @@ def get_final_results(judged_answers,
 def _generic_llmjudge_postprocess(judgement: str,
                                   true_tag: str = 'A',
                                   false_tag: str = 'B'):
-    match = re.search(rf'({re.escape(true_tag)}|{re.escape(false_tag)})',
-                      judgement)
-    grade_letter = match.group(0) if match else 'unknown'
+    # Security: take the LAST match, not the first. The model-under-test's
+    # output is interpolated verbatim into the judge prompt, so an early
+    # injected verdict tag (e.g. "A. ") echoed in the judge's response would
+    # win over the judge's actual final verdict with first-match re.search.
+    matches = re.findall(rf'({re.escape(true_tag)}|{re.escape(false_tag)})',
+                         judgement)
+    grade_letter = matches[-1] if matches else 'unknown'
     return grade_letter
 
 


### PR DESCRIPTION
## Summary

`_generic_llmjudge_postprocess` in `generic.py` used `re.search` (first-match, unanchored) to extract the A/B verdict from the judge's response. The model-under-test's output is interpolated verbatim into the judge prompt (via `{prediction}` in configs), so an early injected verdict tag (e.g. starting the answer with "A. ") that gets echoed in the judge's response wins over the judge's actual final verdict.

This is the **verdict-injection** class — the same pattern fixed across deepeval, ragas, guardrails-ai, promptfoo, instructor, CrewAI, LlamaIndex, AutoGPT, lighteval, HumanEval, and EvalPlus.

## Impact

This **shared helper** (`_generic_llmjudge_postprocess`) is used by **13+ datasets** across OpenCompass, including:
- MedXpertQA, Medbullets, medmcqa, supergpqa (medical/science QA)
- livereasonbench, simpleqa (reasoning)
- matbench, mtbench101, writingbench (subjective evaluation)
- clbench, fofo (format compliance)

A model that prepends its answer with the correct verdict tag ("A. ") can flip a binary correct/incorrect judgment on any of these benchmarks.

## Fix

Switch from `re.search` (first-match) to `re.findall` + take the **last** match. The judge's rubric instructs it to end with the verdict, so the last match is the authoritative one.

## Verified

```
Judge response: "A. The model output suggests A. However the real answer is B."
  vuln:   A (injected wins) 
  fixed:  B (real verdict wins)

Normal response: "The answer is B."
  vuln:   B
  fixed:  B (unchanged)
```

## Checklist

- [x] Code compiles
- [x] Fix verified: injected verdict no longer wins, normal responses unaffected
- [x] Same pattern shipped to 10+ other eval frameworks
