### PR TITLE
[Fix] Enforce the retry limit for OpenAI API errors

### DIFF
--- a/opencompass/models/openai_api.py
+++ b/opencompass/models/openai_api.py
@@ -270,6 +270,7 @@ class OpenAI(BaseAPIModel):
 
         max_num_retries = 0
         while max_num_retries < self.retry:
+            max_num_retries += 1
             key = self._next_valid_key()
 
             header = {
@@ -407,7 +408,6 @@ class OpenAI(BaseAPIModel):
                     )
             finally:
                 self.release()
-            max_num_retries += 1
 
         raise RuntimeError('Calling OpenAI failed after retrying for '
                            f'{max_num_retries} times. Check the logs for '

--- a/tests/models/test_openai_api.py
+++ b/tests/models/test_openai_api.py
@@ -169,6 +169,29 @@ class TestOpenAI(unittest.TestCase):
         self.assertEqual(results[0], 'Generated response')
         self.assertEqual(mock_requests.post.call_count, 2)
 
+    @patch('opencompass.models.openai_api.tiktoken', create=True)
+    @patch('opencompass.models.openai_api.requests.post')
+    @patch.dict('os.environ', {'OPENAI_API_KEY': 'test-key'})
+    def test_generate_stops_after_retry_limit(self, mock_post,
+                                              mock_tiktoken):
+        mock_enc = MagicMock()
+        mock_enc.encode.return_value = [1, 2, 3]
+        mock_tiktoken.encoding_for_model.return_value = mock_enc
+
+        rate_limited = MagicMock()
+        rate_limited.status_code = 429
+        rate_limited.content.decode.return_value = 'rate limited'
+        mock_post.side_effect = [
+            rate_limited,
+            rate_limited,
+            AssertionError('request exceeded retry limit'),
+        ]
+
+        model = OpenAI(path='gpt-3.5-turbo', retry=2)
+
+        with self.assertRaisesRegex(RuntimeError, 'after retrying for 2'):
+            model.generate(['Hello'], max_out_len=100)
+
 
 class TestOpenAISDK(unittest.TestCase):
     """Test cases for OpenAISDK."""


### PR DESCRIPTION
## Summary

- count each legacy OpenAI API request attempt before entering response handling
- stop non-200 responses from bypassing the configured retry limit
- add a regression test that fails if `retry=2` makes a third request

## Root cause

The retry counter was incremented at the end of the loop. Non-200 responses use `continue` inside the `try`, so Python ran the existing `finally` block but skipped the counter increment. Persistent API errors could therefore retry forever.

Moving the increment to the start of each attempt preserves successful responses and semaphore release behavior while ensuring every request consumes one retry.

## Validation

- `python -m pytest tests/models/test_openai_api.py -vv` — 13 passed
- `flake8 opencompass/models/openai_api.py tests/models/test_openai_api.py`
- `git diff --check`
