### PR TITLE
[Fix] Prevent return-value deception in code evaluators

### DIFF
--- a/opencompass/datasets/LCBench.py
+++ b/opencompass/datasets/LCBench.py
@@ -15,6 +15,9 @@ from datasets import DatasetDict, concatenate_datasets, load_dataset
 from opencompass.openicl.icl_evaluator import BaseEvaluator
 from opencompass.registry import ICL_EVALUATORS, LOAD_DATASET
 from opencompass.utils import get_data_path
+from opencompass.utils.code_execution import (TYPE_AWARE_EQUAL_NAME,
+                                              make_assertions_type_aware,
+                                              type_aware_equal)
 
 from .base import BaseDataset
 
@@ -130,21 +133,18 @@ class LCEvaluator(BaseEvaluator):
 
                 # Try each code block until one passes
                 for code_idx, code_block in enumerate(code_blocks):
-                    test_programs = self._process_test(refer, code_block)
-
-                    # Submit each test program variant for execution
-                    for prog_idx, program in enumerate(test_programs):
-                        future = executor.submit(
-                            execution,
-                            program,
-                            (
-                                i,
-                                code_idx,
-                                prog_idx,
-                            ),  # Pass indices for tracking
-                            3,
-                        )
-                        futures.append(future)
+                    test_program = self._process_test(refer, code_block)
+                    future = executor.submit(
+                        execution,
+                        test_program,
+                        (
+                            i,
+                            code_idx,
+                            0,
+                        ),
+                        3,
+                    )
+                    futures.append(future)
 
         from tqdm import tqdm
 
@@ -291,10 +291,7 @@ class LCEvaluator(BaseEvaluator):
                 # Use the modified test
                 test_case = modified_test
 
-        formatted = code + '\n'
-        formatted += test_case
-        # breakpoint()
-        return formatted
+        return code, make_assertions_type_aware(test_case)
 
 
 def execution(programs, task_ids, timeout):
@@ -313,10 +310,13 @@ def execution(programs, task_ids, timeout):
         try:
             # Add exec globals to prevent the exec to raise
             # unnecessary NameError for correct answer
+            code, test_case = programs
             exec_globals = {}
             with swallow_io():
                 with time_limit(timeout):
-                    exec(programs, exec_globals)
+                    exec(code, exec_globals)
+                    exec_globals[TYPE_AWARE_EQUAL_NAME] = type_aware_equal
+                    exec(test_case, exec_globals)
             key.append('pass')
         except TimeOutException:
             key.append('timeout')

--- a/opencompass/datasets/apps.py
+++ b/opencompass/datasets/apps.py
@@ -27,6 +27,7 @@ except ImportError:
 
 from opencompass.openicl.icl_evaluator import BaseEvaluator
 from opencompass.registry import ICL_EVALUATORS, LOAD_DATASET
+from opencompass.utils.code_execution import type_aware_equal
 
 from .base import BaseDataset
 
@@ -490,11 +491,12 @@ def run_test(sample, test=None, debug=False):
                     if isinstance(output, tuple):
                         output = list(output)
 
-                    tmp_result = output == in_outs['outputs'][index]
+                    tmp_result = type_aware_equal(output,
+                                                  in_outs['outputs'][index])
                     if isinstance(in_outs['outputs'][index],
                                   list) and in_outs['outputs'][index]:
-                        tmp_result = tmp_result or (
-                            output == in_outs['outputs'][index][0])
+                        tmp_result = tmp_result or type_aware_equal(
+                            output, in_outs['outputs'][index][0])
 
                     # ground truth sequences are not tuples
                     try:

--- a/opencompass/datasets/livecodebench/evaluator.py
+++ b/opencompass/datasets/livecodebench/evaluator.py
@@ -10,6 +10,7 @@ from tqdm import tqdm
 from opencompass.openicl.icl_evaluator import BaseEvaluator
 from opencompass.registry import ICL_EVALUATORS
 from opencompass.utils import get_logger
+from opencompass.utils.code_execution import TYPE_AWARE_EQUAL_NAME
 
 from .execute_utils import BASE_IMPORTS, codeexecute_check_correctness
 from .extract_utils import (extract_code_execution, extract_code_generation,
@@ -335,7 +336,8 @@ def evaluate_score(args) -> list[bool]:
         if i in g:
             pass
         else:
-            code_to_execute = f'{BASE_IMPORTS}\n{c}\nassert {o} == {g}'
+            code_to_execute = (f'{BASE_IMPORTS}\n{c}',
+                               f'assert {TYPE_AWARE_EQUAL_NAME}({o}, {g})')
             execution_results.append(
                 codeexecute_check_correctness(code_to_execute, 3))
     if len(execution_results) == 0:

--- a/opencompass/datasets/livecodebench/execute_utils.py
+++ b/opencompass/datasets/livecodebench/execute_utils.py
@@ -25,6 +25,9 @@ import platform
 import signal
 import tempfile
 
+from opencompass.utils.code_execution import (TYPE_AWARE_EQUAL_NAME,
+                                              type_aware_equal)
+
 BASE_IMPORTS = """from itertools import accumulate, chain, combinations, count, permutations, product, groupby, islice, repeat
 from copy import deepcopy
 from string import ascii_lowercase
@@ -103,10 +106,13 @@ def unsafe_execute(check_program, result, timeout):
 
         # Run program.
         try:
+            code, test_case = check_program
             exec_globals = {}
             with swallow_io():
                 with time_limit(timeout):
-                    exec(check_program, exec_globals)
+                    exec(code, exec_globals)
+                    exec_globals[TYPE_AWARE_EQUAL_NAME] = type_aware_equal
+                    exec(test_case, exec_globals)
             result.append('passed')
         except TimeoutException:
             result.append('timed out')

--- a/opencompass/datasets/livecodebench/testing_util.py
+++ b/opencompass/datasets/livecodebench/testing_util.py
@@ -18,6 +18,8 @@ from unittest.mock import mock_open, patch
 
 import numpy as np
 
+from opencompass.utils.code_execution import type_aware_equal
+
 try:
     from pyext import RuntimeModule
 except ImportError:
@@ -281,11 +283,12 @@ def run_test(sample, test=None, debug=False, timeout=6):
                     if isinstance(output, tuple):
                         output = list(output)
 
-                    tmp_result = output == in_outs['outputs'][index]
+                    tmp_result = type_aware_equal(output,
+                                                  in_outs['outputs'][index])
                     if (isinstance(in_outs['outputs'][index], list)
                             and in_outs['outputs'][index]):
-                        tmp_result = tmp_result or (
-                            output == in_outs['outputs'][index][0])
+                        tmp_result = tmp_result or type_aware_equal(
+                            output, in_outs['outputs'][index][0])
 
                     # ground truth sequences are not tuples
                     try:

--- a/opencompass/datasets/mbpp.py
+++ b/opencompass/datasets/mbpp.py
@@ -18,6 +18,9 @@ from datasets import Dataset, DatasetDict, concatenate_datasets, load_dataset
 from opencompass.openicl.icl_evaluator import BaseEvaluator
 from opencompass.registry import ICL_EVALUATORS, LOAD_DATASET
 from opencompass.utils import get_data_path
+from opencompass.utils.code_execution import (TYPE_AWARE_EQUAL_NAME,
+                                              make_assertions_type_aware,
+                                              type_aware_equal)
 
 from .base import BaseDataset
 
@@ -345,9 +348,7 @@ class MBPPEvaluator(BaseEvaluator):
         return text
 
     def _process_test(self, test_case, pred):
-        formatted = pred + '\n'
-        formatted += test_case
-        return formatted
+        return pred, make_assertions_type_aware(test_case)
 
 
 @ICL_EVALUATORS.register_module()
@@ -392,10 +393,13 @@ def _execution(programs, timeout, key):
     try:
         # Add exec globals to prevent the exec to raise
         # unnecessary NameError for correct answer
+        code, test_case = programs
         exec_globals = {}
         with swallow_io():
             with time_limit(timeout):
-                exec(programs, exec_globals)
+                exec(code, exec_globals)
+                exec_globals[TYPE_AWARE_EQUAL_NAME] = type_aware_equal
+                exec(test_case, exec_globals)
         key.append('pass')
     except TimeOutException:
         key.append('timeout')

--- a/opencompass/datasets/taco.py
+++ b/opencompass/datasets/taco.py
@@ -28,6 +28,7 @@ except ImportError:
 
 from opencompass.openicl.icl_evaluator import BaseEvaluator
 from opencompass.registry import ICL_EVALUATORS, LOAD_DATASET
+from opencompass.utils.code_execution import type_aware_equal
 
 from .base import BaseDataset
 
@@ -451,11 +452,12 @@ def run_test(sample, test=None, debug=False):
                     if isinstance(output, tuple):
                         output = list(output)
 
-                    tmp_result = output == in_outs['outputs'][index]
+                    tmp_result = type_aware_equal(output,
+                                                  in_outs['outputs'][index])
                     if isinstance(in_outs['outputs'][index],
                                   list) and in_outs['outputs'][index]:
-                        tmp_result = tmp_result or (
-                            output == in_outs['outputs'][index][0])
+                        tmp_result = tmp_result or type_aware_equal(
+                            output, in_outs['outputs'][index][0])
 
                     # ground truth sequences are not tuples
                     try:

--- a/opencompass/utils/code_execution.py
+++ b/opencompass/utils/code_execution.py
@@ -1,0 +1,87 @@
+import ast
+from collections.abc import Mapping
+from typing import Any
+
+TYPE_AWARE_EQUAL_NAME = '__opencompass_type_aware_equal'
+
+
+def type_aware_equal(actual: Any, expected: Any) -> bool:
+    """Compare values without accepting forged ``__eq__`` on return objects."""
+    if type(actual) is not type(expected):
+        return False
+
+    if isinstance(actual, (list, tuple)):
+        return (len(actual) == len(expected) and all(
+            type_aware_equal(a, e) for a, e in zip(actual, expected)))
+
+    if isinstance(actual, Mapping):
+        if len(actual) != len(expected):
+            return False
+
+        matched_expected_keys = set()
+        for actual_key, actual_value in actual.items():
+            match_idx = None
+            for idx, (expected_key,
+                      expected_value) in enumerate(expected.items()):
+                if idx in matched_expected_keys:
+                    continue
+                if (type_aware_equal(actual_key, expected_key)
+                        and type_aware_equal(actual_value, expected_value)):
+                    match_idx = idx
+                    break
+            if match_idx is None:
+                return False
+            matched_expected_keys.add(match_idx)
+        return True
+
+    if isinstance(actual, (set, frozenset)):
+        if len(actual) != len(expected):
+            return False
+
+        expected_items = list(expected)
+        matched_expected_items = set()
+        for actual_item in actual:
+            match_idx = None
+            for idx, expected_item in enumerate(expected_items):
+                if idx in matched_expected_items:
+                    continue
+                if type_aware_equal(actual_item, expected_item):
+                    match_idx = idx
+                    break
+            if match_idx is None:
+                return False
+            matched_expected_items.add(match_idx)
+        return True
+
+    try:
+        result = actual == expected
+    except Exception:
+        return False
+    return type(result) is bool and result
+
+
+class _TypeAwareAssertTransformer(ast.NodeTransformer):
+    """Replace ``assert actual == expected`` with a type-aware comparison."""
+
+    def visit_Assert(self, node: ast.Assert) -> ast.Assert:
+        self.generic_visit(node)
+        comparison = node.test
+        if (isinstance(comparison, ast.Compare) and len(comparison.ops) == 1
+                and isinstance(comparison.ops[0], ast.Eq)):
+            node.test = ast.Call(
+                func=ast.Name(id=TYPE_AWARE_EQUAL_NAME, ctx=ast.Load()),
+                args=[comparison.left, comparison.comparators[0]],
+                keywords=[],
+            )
+        return node
+
+
+def make_assertions_type_aware(source: str) -> str:
+    """Harden direct equality assertions in a dataset-provided test program."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return source
+    tree = _TypeAwareAssertTransformer().visit(tree)
+    ast.fix_missing_locations(tree)
+    return ast.unparse(tree)

--- a/tests/datasets/test_code_execution.py
+++ b/tests/datasets/test_code_execution.py
@@ -1,0 +1,51 @@
+import unittest
+
+from opencompass.utils.code_execution import (TYPE_AWARE_EQUAL_NAME,
+                                              make_assertions_type_aware,
+                                              type_aware_equal)
+
+
+class _AlwaysEqual:
+
+    def __eq__(self, other):
+        return True
+
+
+class _AlwaysEqualInt(int):
+
+    def __new__(cls):
+        return int.__new__(cls, 999)
+
+    def __eq__(self, other):
+        return True
+
+
+class TestCodeExecution(unittest.TestCase):
+
+    def test_type_aware_equal_rejects_eq_override(self):
+        self.assertFalse(type_aware_equal(_AlwaysEqual(), 1))
+
+    def test_type_aware_equal_rejects_nested_eq_override(self):
+        self.assertFalse(type_aware_equal([_AlwaysEqualInt()], [1]))
+
+    def test_type_aware_equal_accepts_nested_builtin_value(self):
+        self.assertTrue(type_aware_equal({'value': [1, 2]}, {'value': [1, 2]}))
+
+    def test_type_aware_assertion_rejects_eq_override(self):
+        test_program = make_assertions_type_aware('assert solve() == 1')
+        namespace = {
+            'solve': _AlwaysEqual,
+            TYPE_AWARE_EQUAL_NAME: type_aware_equal,
+        }
+
+        with self.assertRaises(AssertionError):
+            exec(test_program, namespace)
+
+    def test_type_aware_assertion_accepts_matching_builtin_value(self):
+        test_program = make_assertions_type_aware('assert solve() == 1')
+        namespace = {
+            'solve': lambda: 1,
+            TYPE_AWARE_EQUAL_NAME: type_aware_equal,
+        }
+
+        exec(test_program, namespace)


### PR DESCRIPTION
Fix https://github.com/open-compass/opencompass/issues/2535