### PR TITLE
[Fix] Support Transformers 5 tokenization

### DIFF
--- a/opencompass/models/huggingface.py
+++ b/opencompass/models/huggingface.py
@@ -295,11 +295,11 @@ class HuggingFace(BaseModel):
                 conv.append_message(conv.roles[1], None)
                 inputs[i] = conv.get_prompt()
 
-        # step-1: tokenize the input with batch_encode_plus
-        tokens = self.tokenizer.batch_encode_plus(inputs,
-                                                  padding=True,
-                                                  truncation=True,
-                                                  max_length=self.max_seq_len)
+        # step-1: tokenize the batched inputs
+        tokens = self.tokenizer(inputs,
+                                padding=True,
+                                truncation=True,
+                                max_length=self.max_seq_len)
         tokens = {
             k: torch.tensor(np.array(tokens[k]), device=self.model.device)
             for k in tokens if k in ['input_ids', 'attention_mask']

--- a/opencompass/models/huggingface_above_v4_33.py
+++ b/opencompass/models/huggingface_above_v4_33.py
@@ -302,7 +302,7 @@ class HuggingFacewithChatTemplate(BaseModel):
         self.tokenizer.padding_side = 'right'
         self.tokenizer.truncation_side = 'right'
 
-        tokens = self.tokenizer.batch_encode_plus(messages, **tokenize_kwargs)
+        tokens = self.tokenizer(messages, **tokenize_kwargs)
 
         tokens = {k: v.to(self.model.device) for k, v in tokens.items()}
         outputs = self.model(**tokens)[0]
@@ -466,11 +466,11 @@ class HuggingFacewithChatTemplate(BaseModel):
         )
         if self.fastchat_template:
             messages = _format_with_fast_chat_template(messages, self.fastchat_template)
-            tokens = self.tokenizer.batch_encode_plus(messages, **tokenize_kwargs)
+            tokens = self.tokenizer(messages, **tokenize_kwargs)
         else:
             messages = [self.tokenizer.apply_chat_template(m, add_generation_prompt=True, tokenize=False) for m in messages]
             tokenize_kwargs['add_special_tokens'] = False
-            tokens = self.tokenizer.batch_encode_plus(messages, **tokenize_kwargs)
+            tokens = self.tokenizer(messages, **tokenize_kwargs)
 
         tokens = {k: v.to(self.model.device) for k, v in tokens.items()}
 
@@ -592,7 +592,7 @@ class HuggingFaceBaseModel(HuggingFacewithChatTemplate):
                 input_ids = torch.cat([input_ids[:, : self.max_seq_len // 2], input_ids[:, - self.max_seq_len // 2:]], dim=-1)
             tokens = {'input_ids': input_ids, }
         else:
-            tokens = self.tokenizer.batch_encode_plus(messages, **tokenize_kwargs)
+            tokens = self.tokenizer(messages, **tokenize_kwargs)
 
         tokens = {k: v.to(self.model.device) for k, v in tokens.items()}
 
@@ -654,7 +654,7 @@ class HuggingFaceBaseModel(HuggingFacewithChatTemplate):
                 input_ids = torch.cat([input_ids[:, : self.max_seq_len // 2], input_ids[:, - self.max_seq_len // 2:]], dim=-1)
             tokens = {'input_ids': input_ids, }
         else:
-            tokens = self.tokenizer.batch_encode_plus(messages, **tokenize_kwargs)
+            tokens = self.tokenizer(messages, **tokenize_kwargs)
 
         tokens = {k: v.to(self.model.device) for k, v in tokens.items()}
         outputs = self.model(**tokens)[0]

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -238,7 +238,7 @@ class TestHuggingFace(unittest.TestCase):
         """Test generate with batch_padding=True."""
         mock_tokenizer = MagicMock()
         mock_tokenizer.pad_token_id = 0
-        mock_tokenizer.batch_encode_plus.return_value = {
+        mock_tokenizer.return_value = {
             'input_ids': [[1, 2, 3], [4, 5, 6]],
             'attention_mask': [[1, 1, 1], [1, 1, 1]]
         }
@@ -268,6 +268,10 @@ class TestHuggingFace(unittest.TestCase):
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0], 'Response 1')
         self.assertEqual(results[1], 'Response 2')
+        mock_tokenizer.assert_called_once_with(['Hello', 'Hi'],
+                                               padding=True,
+                                               truncation=True,
+                                               max_length=2048)
         mock_model.generate.assert_called_once()
 
     @patch('transformers.AutoTokenizer')

--- a/tests/models/test_huggingface_above_v4_33.py
+++ b/tests/models/test_huggingface_above_v4_33.py
@@ -90,7 +90,7 @@ class TestHuggingFacewithChatTemplate(unittest.TestCase):
         mock_input_ids.shape = [1, 3]  # batch_size=1, seq_len=3
         mock_attention_mask = MagicMock()
         mock_attention_mask.to.return_value = mock_attention_mask
-        mock_tokenizer.batch_encode_plus.return_value = {
+        mock_tokenizer.return_value = {
             'input_ids': mock_input_ids,
             'attention_mask': mock_attention_mask
         }
@@ -125,6 +125,13 @@ class TestHuggingFacewithChatTemplate(unittest.TestCase):
 
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0], 'Generated response')
+        mock_tokenizer.assert_called_once_with(
+            ['Formatted prompt'],
+            return_tensors='pt',
+            padding=True,
+            truncation=True,
+            add_special_tokens=False,
+            max_length=2048)
         mock_model.generate.assert_called_once()
 
     @patch('transformers.AutoTokenizer')
@@ -214,7 +221,7 @@ class TestHuggingFaceBaseModel(unittest.TestCase):
         mock_input_ids.to.return_value = mock_input_ids
         mock_attention_mask = MagicMock()
         mock_attention_mask.to.return_value = mock_attention_mask
-        mock_tokenizer.batch_encode_plus.return_value = {
+        mock_tokenizer.return_value = {
             'input_ids': mock_input_ids,
             'attention_mask': mock_attention_mask
         }
@@ -242,6 +249,13 @@ class TestHuggingFaceBaseModel(unittest.TestCase):
 
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0], 'Generated response')
+        mock_tokenizer.assert_called_once_with(
+            ['Hello'],
+            return_tensors='pt',
+            padding=True,
+            truncation=True,
+            add_special_tokens=True,
+            max_length=2048)
         mock_model.generate.assert_called_once()
 
     @patch('transformers.AutoTokenizer')


### PR DESCRIPTION
## Motivation

Fixes #2573.

Transformers 5 removed the public `batch_encode_plus` tokenizer API. Models that require Transformers 5, such as Qwen3.5, therefore fail in `HuggingFacewithChatTemplate.generate` before inference starts.

## Modification

- Use the tokenizer's public `__call__` API for batched tokenization in both Hugging Face backends.
- Cover the chat-template and base-model generation paths with assertions that verify the supported tokenizer API is used.
- Keep tokenization arguments and behavior unchanged; only the deprecated entry point is replaced.

## BC-breaking

No. Calling the tokenizer directly is supported by both the repository's minimum Transformers version and Transformers 5.x.

## Validation

- `PYTHONPATH=/tmp/transformers-5.12.1:/tmp/opencompass-2573-test-deps /home/cherry-cloud/ai-lab/.venv/bin/python -m pytest tests/models/test_huggingface.py tests/models/test_huggingface_above_v4_33.py -q` (15 passed)
- `python -m py_compile` on the two changed implementation files and their tests
- `git diff --check`

## Checklist

- [x] Bug fixes are covered by unit tests.
- [x] The affected Hugging Face model tests pass with Transformers 5.12.1.
- [x] No documentation change is required; the public model configuration is unchanged.
