### PR TITLE
Fix option matching without cushion

### DIFF
--- a/opencompass/utils/text_postprocessors.py
+++ b/opencompass/utils/text_postprocessors.py
@@ -89,7 +89,7 @@ def first_option_postprocess(text: str, options: str, cushion=True) -> str:
         f'答案为\s*([{options}])',
         f'答案选\s*([{options}])',
         f'选择?\s*([{options}])',
-        f'故选?\s*([{options}])'
+        f'故选?\s*([{options}])',
         f'只有选?项?\s?([{options}])\s?是?对',
         f'只有选?项?\s?([{options}])\s?是?错',
         f'只有选?项?\s?([{options}])\s?不?正确',
@@ -124,7 +124,7 @@ def first_option_postprocess(text: str, options: str, cushion=True) -> str:
         f'[Tt]he answer to the question is:?\s+\(?([{options}])\)?',
         f'^选项\s?([{options}])',
         f'^([{options}])\s?选?项',
-        f'(\s|^)[{options}][\s。，,：:\.$]',
+        rf'(?:\s|^)([{options}])(?:[\s。，,：:.]|$)',
         f'1.\s?(.*?)$',
         f'1.\s?([{options}])[.。$]?$',
     ]

--- a/tests/utils/test_text_postprocessors.py
+++ b/tests/utils/test_text_postprocessors.py
@@ -39,6 +39,15 @@ class TestTextPostprocessors(unittest.TestCase):
         text = '答案是 B'
         self.assertEqual(tp.first_option_postprocess(text, 'ABCD'), 'B')
 
+    def test_first_option_postprocess_without_cushion(self):
+        self.assertEqual(
+            tp.first_option_postprocess('只有选项 B 是对', 'ABCD', cushion=False),
+            'B')
+        self.assertEqual(
+            tp.first_option_postprocess('reason A because',
+                                        'ABCD',
+                                        cushion=False), 'A')
+
     def test_last_option_postprocess(self):
         text = 'A then C then B'
         self.assertEqual(tp.last_option_postprocess(text, 'ABC'), 'B')


### PR DESCRIPTION
## Summary

- restore the missing separator between two Chinese answer patterns
- capture the option rather than its leading whitespace in the generic boundary pattern
- add regression coverage with `cushion=False`

## Why

Two adjacent f-strings were implicitly concatenated, making the intended `只有选项 ... 是对` pattern unreachable. A later fallback pattern also captured the boundary as group 1, so matches such as `reason A because` were discarded when cushion matching was disabled.

## Validation

- targeted checks for `只有选项 B 是对` and `reason A because`
- existing `答案是 B` behavior retained
- `git diff --check`
