### PR TITLE
Reject unsupported WildBench evaluation modes

### DIFF
--- a/opencompass/datasets/subjective/wildbench.py
+++ b/opencompass/datasets/subjective/wildbench.py
@@ -217,6 +217,10 @@ def parse_conversation(conversation):
 class WildBenchDataset(BaseDataset):
 
     def load(self, path: str, K=-1, eval_mode='pair', *args, **kwargs):
+        if eval_mode not in ('single', 'pair'):
+            raise ValueError(
+                f'Eval mode {eval_mode} must be either "single" or "pair".')
+        prompt_template = score_prompt if eval_mode == 'single' else pair_prompt
         path = get_data_path(path, local_mode=True)
         dataset = DatasetDict()
         raw_data = []
@@ -230,13 +234,7 @@ class WildBenchDataset(BaseDataset):
                 for checklist_item in item['checklist']:
                     checklist_mardkdown += f'- {checklist_item}\n'
 
-                if eval_mode == 'single':
-                    prompt = score_prompt
-                elif eval_mode == 'pair':
-                    prompt = pair_prompt
-                else:
-                    assert NotImplementedError(
-                        f'Eval mode {eval_mode} not in single or pair.')
+                prompt = prompt_template
 
                 prompt = prompt.replace('{history}', history)
                 prompt = prompt.replace('{user_query}', last_query)
@@ -414,9 +412,8 @@ def wildbench_bradleyterry_postprocess(
         cur_dict['primary_tag'] = reference['primary_tag']
         # Extract first tag from list and set as categorical level.
         # Can be used as categorical variable in Bradley-Terry model
-        cur_dict['secondary_tag'] = (reference['secondary_tag'][0]
-                                     if len(reference['secondary_tag']) > 0
-                                     else 'Others')
+        cur_dict['secondary_tag'] = (reference['secondary_tag'][0] if len(
+            reference['secondary_tag']) > 0 else 'Others')
         # Keep original secondary tag list for reference
         cur_dict['secondary_tags'] = reference['secondary_tag']
         cur_dict['model_a'] = reference['answer1']
@@ -448,6 +445,10 @@ def wildbench_bradleyterry_postprocess(
 class WildBenchWithRawPromptDataset(BaseDataset):
 
     def load(self, path: str, K=-1, eval_mode='pair', *args, **kwargs):
+        if eval_mode not in ('single', 'pair'):
+            raise ValueError(
+                f'Eval mode {eval_mode} must be either "single" or "pair".')
+        prompt_template = score_prompt if eval_mode == 'single' else pair_prompt
         path = get_data_path(path, local_mode=True)
         raw_data = []
         with open(path, 'r', encoding='utf-8') as file:
@@ -478,13 +479,7 @@ class WildBenchWithRawPromptDataset(BaseDataset):
                 for checklist_item in item['checklist']:
                     checklist_mardkdown += f'- {checklist_item}\n'
 
-                if eval_mode == 'single':
-                    prompt = score_prompt
-                elif eval_mode == 'pair':
-                    prompt = pair_prompt
-                else:
-                    assert NotImplementedError(
-                        f'Eval mode {eval_mode} not in single or pair.')
+                prompt = prompt_template
 
                 prompt = prompt.replace('{history}', history)
                 prompt = prompt.replace('{user_query}', last_query)

--- a/tests/datasets/test_wildbench.py
+++ b/tests/datasets/test_wildbench.py
@@ -1,0 +1,18 @@
+import unittest
+
+from opencompass.datasets.subjective.wildbench import (
+    WildBenchDataset, WildBenchWithRawPromptDataset)
+
+
+class TestWildBenchDataset(unittest.TestCase):
+
+    def test_invalid_eval_mode(self):
+        for dataset_cls in (WildBenchDataset, WildBenchWithRawPromptDataset):
+            with self.subTest(dataset_cls=dataset_cls.__name__):
+                with self.assertRaisesRegex(ValueError,
+                                            'must be either "single" or "pair"'):
+                    dataset_cls.load(None, 'unused', eval_mode='invalid')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- validate WildBench evaluation mode before loading the dataset
- reject unsupported modes consistently in both WildBench loaders
- add regression coverage for both loader variants

## Why

The previous `assert NotImplementedError(...)` asserted a truthy exception object and therefore never raised. Invalid modes later failed with an unrelated unbound-local error.

## Validation

- compiled the modified module and new test
- isolated both loader methods and verified invalid modes raise `ValueError`
- `git diff --check`
