### PR TITLE
Fix BABILong 2k config syntax

### DIFF
--- a/opencompass/configs/datasets/babilong/babilong_2k_gen.py
+++ b/opencompass/configs/datasets/babilong/babilong_2k_gen.py
@@ -29,7 +29,7 @@ for task in tasks:
                 ),
             ),
             retriever=dict(type=ZeroRetriever),
-            inferencer=dict(type=GenInferencer， max_seq_len=max_seq_len),
+            inferencer=dict(type=GenInferencer, max_seq_len=max_seq_len),
         ),
         'eval_cfg': dict(
             evaluator=dict(type=BabiLongEvaluator),


### PR DESCRIPTION
## Summary

- replace the full-width comma in the BABILong 2k generation config with a valid Python comma

## Why

`babilong_2k_gen.py` could not be parsed, so selecting this otherwise supported dataset config failed before evaluation started.

## Validation

- `python -m py_compile opencompass/configs/datasets/babilong/babilong_2k_gen.py`
- `git diff --check`
