### PR TITLE
Fix multi-replica metric aggregation

### DIFF
--- a/opencompass/openicl/icl_evaluator/icl_base_evaluator.py
+++ b/opencompass/openicl/icl_evaluator/icl_base_evaluator.py
@@ -230,8 +230,14 @@ class BaseEvaluator:
                 detail.pop('predictions')
             return eval_results
 
-        # If there are no details, return results
-        return results
+        # Preserve the existing result shape for a single replica and for
+        # non-numeric fields, while returning averaged metrics across runs.
+        if n == 1:
+            return results
+        for key, value in results.items():
+            if not isinstance(value, (float, int)):
+                eval_results[key] = value
+        return eval_results
 
     def score(self):
         raise NotImplementedError("Method hasn't been implemented yet")

--- a/tests/openicl/test_average_ppl_evaluator.py
+++ b/tests/openicl/test_average_ppl_evaluator.py
@@ -14,3 +14,18 @@ def test_average_ppl_evaluator_without_predictions():
     )
 
     assert result == {'average_ppl': 2.0}
+
+
+def test_average_ppl_evaluator_aggregates_multiple_replicas():
+    dataset = Dataset.from_list([{
+        'text': f'example {index}'
+    } for index in range(4)])
+
+    result = AveragePPLEvaluator().evaluate(
+        k=1,
+        n=2,
+        original_dataset=dataset,
+        ppl=[1.0, 3.0, 10.0, 20.0],
+    )
+
+    assert result == {'average_ppl (2 runs average)': 8.5}


### PR DESCRIPTION
## Summary

- return averaged metrics for no-details evaluators when multiple replicas are evaluated
- retain the existing single-replica and non-numeric result shape
- add a two-replica AveragePPL regression test

## Why

`BaseEvaluator.evaluate` already built `eval_results` across replicas, but its no-details path returned the loop's final `results` value. Metrics such as AveragePPL therefore silently discarded every replica except the last one.

## Validation

- two replica means of `2.0` and `15.0` now produce `8.5`
- single-replica behavior remains unchanged
- `git diff --check`
- compiled the modified evaluator and test
