### PR TITLE
Fix QuALITY hard accuracy calculation

### DIFF
--- a/opencompass/datasets/QuALITY.py
+++ b/opencompass/datasets/QuALITY.py
@@ -56,6 +56,10 @@ class QuALITYEvaluator(BaseEvaluator):
                 easy.append(answer)
             else:
                 hard.append(answer)
-        return dict(easy_acc=sum(easy) / len(easy) * 100,
-                    hard_acc=sum(hard) / len(easy) * 100,
-                    all_acc=sum(all) / len(all) * 100)
+
+        def accuracy(answers):
+            return sum(answers) / len(answers) * 100 if answers else 0.0
+
+        return dict(easy_acc=accuracy(easy),
+                    hard_acc=accuracy(hard),
+                    all_acc=accuracy(all))

--- a/tests/datasets/test_quality.py
+++ b/tests/datasets/test_quality.py
@@ -1,0 +1,79 @@
+import unittest
+
+from opencompass.datasets.QuALITY import QuALITYEvaluator
+
+
+class TestQuALITYEvaluator(unittest.TestCase):
+
+    def setUp(self):
+        self.evaluator = QuALITYEvaluator()
+
+    def test_scores_easy_and_hard_subsets_independently(self):
+        result = self.evaluator.score(
+            predictions=['A', 'B', 'C'],
+            references=['A', 'B', 'C'],
+            test_set=[
+                {
+                    'difficult': 0
+                },
+                {
+                    'difficult': 0
+                },
+                {
+                    'difficult': 1
+                },
+            ],
+        )
+
+        self.assertEqual(result, {
+            'easy_acc': 100.0,
+            'hard_acc': 100.0,
+            'all_acc': 100.0,
+        })
+
+    def test_hard_only_subset(self):
+        result = self.evaluator.score(
+            predictions=['A', 'B'],
+            references=['A', 'A'],
+            test_set=[{
+                'difficult': 1
+            }, {
+                'difficult': 1
+            }],
+        )
+
+        self.assertEqual(result, {
+            'easy_acc': 0.0,
+            'hard_acc': 50.0,
+            'all_acc': 50.0,
+        })
+
+    def test_easy_only_subset(self):
+        result = self.evaluator.score(
+            predictions=['A', 'B'],
+            references=['A', 'A'],
+            test_set=[{
+                'difficult': 0
+            }, {
+                'difficult': 0
+            }],
+        )
+
+        self.assertEqual(result, {
+            'easy_acc': 50.0,
+            'hard_acc': 0.0,
+            'all_acc': 50.0,
+        })
+
+    def test_empty_input(self):
+        result = self.evaluator.score([], [], [])
+
+        self.assertEqual(result, {
+            'easy_acc': 0.0,
+            'hard_acc': 0.0,
+            'all_acc': 0.0,
+        })
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- calculate QuALITY hard accuracy with the hard subset size
- define empty subset accuracy as `0.0`
- cover mixed, hard-only, easy-only, and empty inputs

## Why

The hard score divided correct hard answers by the number of easy samples. Unequal subset sizes produced incorrect metrics, and a hard-only input raised `ZeroDivisionError`.

## Validation

- 2 easy + 1 hard, all correct: all three metrics are `100.0`
- hard-only, easy-only, and empty inputs return stable metrics
- `python -m py_compile opencompass/datasets/QuALITY.py tests/datasets/test_quality.py`
- `git diff --check`
