### PR TITLE
Fix OpenAI SDK request forwarding

### DIFF
--- a/opencompass/models/openai_api.py
+++ b/opencompass/models/openai_api.py
@@ -747,7 +747,7 @@ class OpenAISDK(OpenAI):
                     model=self.path,
                     max_tokens=max_out_len,
                     n=1,
-                    temperature=self.temperature,
+                    temperature=temperature,
                     messages=messages,
                     extra_body=self.extra_body,
                 )

--- a/opencompass/models/openai_streaming.py
+++ b/opencompass/models/openai_streaming.py
@@ -109,6 +109,9 @@ class OpenAISDKStreaming(OpenAISDK):
 
         assert isinstance(input, (str, list, PromptList))
 
+        if not self.stream:
+            return super()._generate(input, max_out_len, temperature)
+
         messages, max_out_len = self._preprocess_messages(
             input, max_out_len, self.max_seq_len, self.mode,
             self.get_token_len)
@@ -151,19 +154,14 @@ class OpenAISDKStreaming(OpenAISDK):
                         f'[Thread {thread_id}] Start calling OpenAI API '
                         f'with streaming enabled')
 
-                if self.stream:
-                    # Handle streaming response with shorter timeout
-                    stream = self.openai_client.chat.completions.create(
-                        **query_data, timeout=self.timeout)
+                # Handle streaming response with shorter timeout
+                stream = self.openai_client.chat.completions.create(
+                    **query_data, timeout=self.timeout)
 
-                    result = self._handle_stream_response(
-                        stream, thread_id if self.verbose else None)
+                result = self._handle_stream_response(
+                    stream, thread_id if self.verbose else None)
 
-                    return result
-                else:
-                    # Fallback to non-streaming (use parent method)
-                    return super()._generate(input, max_out_len, temperature,
-                                             self.timeout)
+                return result
 
             except (BadRequestError, APIStatusError) as e:
                 status_code = e.status_code

--- a/tests/models/test_openai_api.py
+++ b/tests/models/test_openai_api.py
@@ -260,6 +260,69 @@ class TestOpenAISDK(unittest.TestCase):
     @patch('openai.OpenAI')
     @patch('httpx.Client')
     @patch.dict('os.environ', {'OPENAI_API_KEY': 'test-key'})
+    def test_generate_forwards_call_temperature(
+            self, mock_httpx_client, mock_openai_class, mock_tiktoken):
+        """Test default and per-call temperatures reach the SDK request."""
+        mock_enc = MagicMock()
+        mock_enc.encode.return_value = [1, 2, 3]
+        mock_tiktoken.encoding_for_model.return_value = mock_enc
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = 'Generated response'
+        mock_response.choices[0].message.reasoning_content = None
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai_class.return_value = mock_client
+        mock_httpx_client.return_value = MagicMock()
+
+        model = OpenAISDK(path='gpt-3.5-turbo', max_seq_len=16384)
+        model.acquire = MagicMock()
+        model.release = MagicMock()
+
+        model.generate(['Hello'], max_out_len=100)
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        self.assertEqual(call_kwargs['temperature'], 0.7)
+
+        model.generate(['Hello'], max_out_len=100, temperature=0.2)
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        self.assertEqual(call_kwargs['temperature'], 0.2)
+
+    @patch('opencompass.models.openai_api.tiktoken', create=True)
+    @patch('openai.OpenAI')
+    @patch('httpx.Client')
+    @patch.dict('os.environ', {'OPENAI_API_KEY': 'test-key'})
+    def test_constructor_temperature_overrides_call_temperature(
+            self, mock_httpx_client, mock_openai_class, mock_tiktoken):
+        """Test constructor temperature keeps precedence over call values."""
+        mock_enc = MagicMock()
+        mock_enc.encode.return_value = [1, 2, 3]
+        mock_tiktoken.encoding_for_model.return_value = mock_enc
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = 'Generated response'
+        mock_response.choices[0].message.reasoning_content = None
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai_class.return_value = mock_client
+        mock_httpx_client.return_value = MagicMock()
+
+        model = OpenAISDK(path='gpt-3.5-turbo',
+                          max_seq_len=16384,
+                          temperature=0.1)
+        model.acquire = MagicMock()
+        model.release = MagicMock()
+
+        model.generate(['Hello'], max_out_len=100, temperature=0.8)
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        self.assertEqual(call_kwargs['temperature'], 0.1)
+
+    @patch('opencompass.models.openai_api.tiktoken', create=True)
+    @patch('openai.OpenAI')
+    @patch('httpx.Client')
+    @patch.dict('os.environ', {'OPENAI_API_KEY': 'test-key'})
     def test_generate_with_reasoning_content(self, mock_httpx_client,
                                              mock_openai_class, mock_tiktoken):
         """Test generate with reasoning content."""

--- a/tests/models/test_openai_streaming.py
+++ b/tests/models/test_openai_streaming.py
@@ -65,6 +65,42 @@ class TestOpenAISDKStreaming(unittest.TestCase):
     @patch('opencompass.models.openai_api.tiktoken', create=True)
     @patch('openai.OpenAI')
     @patch.dict('os.environ', {'OPENAI_API_KEY': 'test-key'})
+    def test_generate_with_stream_false(self, mock_openai_class,
+                                        mock_tiktoken):
+        """Test stream=False delegates to the non-streaming SDK request."""
+        mock_enc = MagicMock()
+        mock_enc.encode.return_value = [1, 2, 3]
+        mock_tiktoken.encoding_for_model.return_value = mock_enc
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = 'Generated response'
+        mock_response.choices[0].message.reasoning_content = None
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai_class.return_value = mock_client
+
+        with patch.object(OpenAISDKStreaming,
+                          '_create_fresh_client',
+                          return_value=mock_client):
+            model = OpenAISDKStreaming(path='gpt-3.5-turbo',
+                                       max_seq_len=16384,
+                                       stream=False)
+
+        model.acquire = MagicMock()
+        model.release = MagicMock()
+
+        results = model.generate(['Hello'], max_out_len=100)
+
+        self.assertEqual(results, ['Generated response'])
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        self.assertNotIn('stream', call_kwargs)
+        self.assertEqual(call_kwargs['temperature'], 0.7)
+
+    @patch('opencompass.models.openai_api.tiktoken', create=True)
+    @patch('openai.OpenAI')
+    @patch.dict('os.environ', {'OPENAI_API_KEY': 'test-key'})
     def test_generate_with_streaming(self, mock_openai_class, mock_tiktoken):
         """Test generate with streaming enabled."""
         mock_enc = MagicMock()


### PR DESCRIPTION
## Summary

- forward the effective generation temperature to OpenAI SDK requests
- delegate `OpenAISDKStreaming(stream=False)` to the parent request path with the correct signature
- avoid duplicate preprocessing and rate-limit acquisition in the non-streaming fallback
- add request-level mock regression coverage

## Why

`OpenAISDK._generate` received the effective temperature from `generate` but sent `self.temperature`, which is normally `None`. The streaming adapter's disabled-stream fallback also passed an extra positional timeout argument to the parent method, so generation failed with `TypeError` despite initialization succeeding.

## Validation

- default and per-call temperatures reach the SDK request
- constructor temperature keeps precedence over per-call values
- `stream=False` returns a normal response and does not send the streaming flag
- relevant pre-commit hooks passed
- modified files compile successfully
