### PR TITLE
Bound OpenAI REST retries and requests

### DIFF
--- a/opencompass/models/openai_api.py
+++ b/opencompass/models/openai_api.py
@@ -100,6 +100,8 @@ class OpenAI(BaseAPIModel):
         max_workers (int, optional): Maximum number of worker threads for
             concurrent API requests. For I/O-intensive API calls, recommended
             value is 10-20. Defaults to None (uses CPU count * 2).
+        timeout (float, optional): Timeout in seconds for each HTTP request.
+            Defaults to 3600.
     """
 
     is_api: bool = True
@@ -125,6 +127,7 @@ class OpenAI(BaseAPIModel):
         verbose: bool = False,
         think_tag: str = '</think>',
         max_workers: Optional[int] = None,
+        timeout: float = 3600,
     ):
         super().__init__(
             path=path,
@@ -143,6 +146,7 @@ class OpenAI(BaseAPIModel):
         self.top_logprobs = top_logprobs
         self.extra_body = extra_body
         self.think_tag = think_tag
+        self.timeout = timeout
         # Fallback to gpt-4 as default tokenizer.
         self.tokenizer_path = tokenizer_path or path or 'gpt-4'
         self.tokenizer = None
@@ -271,6 +275,9 @@ class OpenAI(BaseAPIModel):
         max_num_retries = 0
         while max_num_retries < self.retry:
             key = self._next_valid_key()
+            # Count attempts before issuing the request so every early
+            # ``continue`` below is still bounded by ``self.retry``.
+            max_num_retries += 1
 
             header = {
                 'Authorization': f'Bearer {key}',
@@ -326,7 +333,8 @@ class OpenAI(BaseAPIModel):
                 if self.proxy_url is None:
                     raw_response = requests.post(url,
                                                  headers=header,
-                                                 data=json.dumps(data))
+                                                 data=json.dumps(data),
+                                                 timeout=self.timeout)
                 else:
                     proxies = {
                         'http': self.proxy_url,
@@ -340,6 +348,7 @@ class OpenAI(BaseAPIModel):
                         headers=header,
                         data=json.dumps(data),
                         proxies=proxies,
+                        timeout=self.timeout,
                     )
 
                     if self.verbose:
@@ -392,7 +401,9 @@ class OpenAI(BaseAPIModel):
                         continue
                     elif response['error']['code'] == 'insufficient_quota':
                         self.invalid_keys.add(key)
-                        self.logger.warning(f'insufficient_quota key: {key}')
+                        self.logger.warning('An OpenAI API key has '
+                                            'insufficient quota and will be '
+                                            'skipped.')
                         continue
                     elif response['error']['code'] == 'invalid_prompt':
                         self.logger.warning('Invalid prompt:', str(input))
@@ -407,7 +418,6 @@ class OpenAI(BaseAPIModel):
                     )
             finally:
                 self.release()
-            max_num_retries += 1
 
         raise RuntimeError('Calling OpenAI failed after retrying for '
                            f'{max_num_retries} times. Check the logs for '

--- a/tests/models/test_openai_api.py
+++ b/tests/models/test_openai_api.py
@@ -169,6 +169,106 @@ class TestOpenAI(unittest.TestCase):
         self.assertEqual(results[0], 'Generated response')
         self.assertEqual(mock_requests.post.call_count, 2)
 
+    @patch('opencompass.models.openai_api.tiktoken', create=True)
+    @patch('opencompass.models.openai_api.requests')
+    @patch.dict('os.environ', {'OPENAI_API_KEY': 'test-key'})
+    def test_non_200_responses_exhaust_retry_budget(
+            self, mock_requests, mock_tiktoken):
+        """Every non-200 response should consume one retry attempt."""
+        mock_enc = MagicMock()
+        mock_enc.encode.return_value = [1, 2, 3]
+        mock_tiktoken.encoding_for_model.return_value = mock_enc
+
+        for status_code in (429, 500):
+            with self.subTest(status_code=status_code):
+                mock_response = MagicMock()
+                mock_response.status_code = status_code
+                mock_response.content = b'upstream error'
+                mock_requests.post.reset_mock()
+                mock_requests.post.return_value = mock_response
+
+                model = OpenAI(
+                    path='gpt-3.5-turbo',
+                    max_seq_len=16384,
+                    retry=3,
+                )
+                model.acquire = MagicMock()
+                model.release = MagicMock()
+
+                with self.assertRaisesRegex(RuntimeError,
+                                            'retrying for 3 times'):
+                    model.generate(['Hello'], max_out_len=100)
+
+                self.assertEqual(mock_requests.post.call_count, 3)
+
+    @patch('opencompass.models.openai_api.tiktoken', create=True)
+    @patch('opencompass.models.openai_api.requests')
+    @patch.dict('os.environ', {'OPENAI_API_KEY': 'test-key'})
+    def test_request_timeout_is_forwarded(self, mock_requests,
+                                          mock_tiktoken):
+        """The configured timeout should be passed to requests."""
+        mock_enc = MagicMock()
+        mock_enc.encode.return_value = [1, 2, 3]
+        mock_tiktoken.encoding_for_model.return_value = mock_enc
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'choices': [{
+                'message': {
+                    'content': 'Generated response'
+                }
+            }]
+        }
+        mock_requests.post.return_value = mock_response
+
+        model = OpenAI(
+            path='gpt-3.5-turbo',
+            max_seq_len=16384,
+            timeout=12.5,
+        )
+
+        model.generate(['Hello'], max_out_len=100)
+
+        self.assertEqual(mock_requests.post.call_args.kwargs['timeout'], 12.5)
+
+    @patch('opencompass.models.openai_api.tiktoken', create=True)
+    @patch('opencompass.models.openai_api.requests')
+    @patch.dict('os.environ', {'OPENAI_API_KEY': 'super-secret-key'})
+    def test_quota_log_does_not_expose_key(self, mock_requests,
+                                           mock_tiktoken):
+        """Disabling a quota-exhausted key must not leak it to logs."""
+        mock_enc = MagicMock()
+        mock_enc.encode.return_value = [1, 2, 3]
+        mock_tiktoken.encoding_for_model.return_value = mock_enc
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'error': {
+                'code': 'insufficient_quota'
+            }
+        }
+        mock_requests.post.return_value = mock_response
+
+        model = OpenAI(
+            path='gpt-3.5-turbo',
+            max_seq_len=16384,
+            retry=2,
+        )
+        model.acquire = MagicMock()
+        model.release = MagicMock()
+        model.logger = MagicMock()
+
+        with self.assertRaisesRegex(RuntimeError,
+                                    'All keys have insufficient quota'):
+            model.generate(['Hello'], max_out_len=100)
+
+        logged_messages = ' '.join(
+            str(call) for call in model.logger.method_calls)
+        self.assertNotIn('super-secret-key', logged_messages)
+        self.assertIn('insufficient quota', logged_messages)
+
 
 class TestOpenAISDK(unittest.TestCase):
     """Test cases for OpenAISDK."""


### PR DESCRIPTION
## Summary

- make every REST request consume one bounded retry attempt
- add a configurable per-request timeout for direct and proxied requests
- stop logging quota-exhausted API keys
- add mock regressions for persistent 429/500 responses, timeout forwarding, and key redaction

## Why

Several `continue` paths ran before the retry counter incremented. A service that continuously returned a non-200 response could therefore loop forever. Requests also had no timeout, and the insufficient-quota path wrote the full API key to logs.

## Validation

- persistent 429 and 500 responses stop after the configured call count
- timeout reaches `requests.post`
- quota handling still disables invalid keys without exposing their value
- relevant pre-commit hooks passed
- modified files compile successfully
