### PR TITLE
Package dataset runtime resources

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 recursive-include opencompass/configs *.py *.yml *.json *.txt *.md
 recursive-include opencompass/openicl/icl_evaluator/hf_metrics *.py
-recursive-include opencompass/datasets *.py *.yml *.json *.txt *.md *.yaml
+recursive-include opencompass/datasets *.py *.yml *.json *.jsonl *.txt *.md *.yaml

--- a/opencompass/datasets/leval/evaluators.py
+++ b/opencompass/datasets/leval/evaluators.py
@@ -1,10 +1,19 @@
 import json
+from pathlib import Path
 from typing import List
 
 from opencompass.openicl.icl_evaluator import BaseEvaluator
 from opencompass.registry import ICL_EVALUATORS
 from opencompass.utils.prompt import PromptList
 from opencompass.utils.text_postprocessors import general_postprocess
+
+_MODULE_FILE = Path(__file__).resolve()
+
+
+def _load_battle_samples(battle_model: str) -> List[dict]:
+    resource_path = _MODULE_FILE.with_name(f'{battle_model}.pred.jsonl')
+    with resource_path.open(encoding='utf-8') as f:
+        return [json.loads(line) for line in f]
 
 
 @ICL_EVALUATORS.register_module()
@@ -64,12 +73,7 @@ class LEvalGPTEvaluator(BaseEvaluator):
     def score(self, predictions: List, references: List) -> dict:
         system_prompt = "Please act as an impartial judge and evaluate the quality of the responses provided by two AI assistants to the user question about the content of a long document.  You will be given a reference answer written by human, assistant A's answer, and assistant B's answer. Your job is to evaluate which assistant's answer is better. Begin your evaluation by comparing both assistants' answers with the reference answer. Additional details or information that are not mentioned in reference answer cannot be considered as advantages and do not let them sway your judgment. Your evaluation should also consider the relevance to user's question but it is more important to avoid factual errors according to the reference answer. Avoid any position biases and ensure that the order in which the responses were presented does not influence your decision. Do not allow the length of the responses to influence your evaluation. Do not favor certain names of the assistants. Be as objective as possible. After providing your explanation, output your final verdict by strictly following this format: \"[[A]]\" if assistant A is better, \"[[B]]\" if assistant B is better, and \"[[C]]\" for a tie."  # noqa
         prompt_template = "[User Question]\n{question}\n\n[The Start of Reference Answer]\n{reference}\n[The End of Reference Answer]\n\n[The Start of Assistant A's Answer]\n{answer_a}\n[The End of Assistant A's Answer]\n\n[The Start of Assistant B's Answer]\n{answer_b}\n[The End of Assistant B's Answer]"  # noqa
-        battle_samples = []
-        with open(
-                'opencompass/datasets/leval/' + self.battle_model +
-                '.pred.jsonl', 'r') as f:
-            for i, line in enumerate(f):
-                battle_samples.append(json.loads(line))
+        battle_samples = _load_battle_samples(self.battle_model)
 
         score = 0.
         bad_case = 0

--- a/opencompass/datasets/medbench/medbench.py
+++ b/opencompass/datasets/medbench/medbench.py
@@ -1,6 +1,8 @@
 import json
 import os.path as osp
 import sys
+from pathlib import Path
+
 from datasets import Dataset
 from sklearn.metrics import classification_report
 from opencompass.openicl.icl_evaluator import BaseEvaluator
@@ -18,6 +20,15 @@ import re
 from transformers import BasicTokenizer
 from rouge_chinese import Rouge
 basic_tokenizer = BasicTokenizer(tokenize_chinese_chars=True)
+
+_MODULE_FILE = Path(__file__).resolve()
+
+
+def _load_entity_choices():
+    resource_path = _MODULE_FILE.with_name('entity_list.jsonl')
+    with resource_path.open(encoding='utf-8') as f:
+        return json.load(f)
+
 
 @LOAD_DATASET.register_module()
 class MedBenchDataset(BaseDataset):
@@ -117,7 +128,7 @@ def process_generated_results_CMeIE(pred_file):
 
 def process_generated_results_CDN(pred_file):
     structured_output = []
-    answer_choices = json.load(open('./opencompass/datasets/medbench/entity_list.jsonl', 'r'))
+    answer_choices = _load_entity_choices()
     for line in pred_file:
         gen_output = line
 

--- a/setup.py
+++ b/setup.py
@@ -146,6 +146,10 @@ def do_setup():
         },
         license='Apache License 2.0',
         include_package_data=True,
+        package_data={
+            'opencompass.datasets.leval': ['*.jsonl'],
+            'opencompass.datasets.medbench': ['*.jsonl'],
+        },
         packages=find_packages(),
         keywords=[
             'AI',

--- a/tests/datasets/test_packaged_resources.py
+++ b/tests/datasets/test_packaged_resources.py
@@ -1,0 +1,30 @@
+import pytest
+
+from opencompass.datasets.leval.evaluators import _load_battle_samples
+from opencompass.datasets.medbench.medbench import process_generated_results_CDN
+
+
+def test_medbench_cdn_postprocess_is_cwd_independent(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    result = process_generated_results_CDN(['高血压性心脏病'])
+
+    assert result == [[{
+        'entity': '高血压性心脏病',
+        'type': 'normalization',
+    }]]
+
+
+@pytest.mark.parametrize('battle_model', [
+    'claude-100k',
+    'turbo-16k-0613',
+])
+def test_leval_battle_samples_are_cwd_independent(battle_model, tmp_path,
+                                                   monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    samples = _load_battle_samples(battle_model)
+
+    assert samples
+    assert all({'query', 'gt', f'{battle_model}_pred'} <= sample.keys()
+               for sample in samples)


### PR DESCRIPTION
## Summary

- include dataset JSONL resources in source and wheel package metadata
- resolve MedBench and LEval resources relative to their installed modules instead of the process working directory
- add arbitrary-CWD regression coverage for all three packaged resources

## Why

The existing manifest omitted `*.jsonl`, so the MedBench entity list and two LEval battle baselines were absent from built distributions. The runtime readers also used repository-root-relative paths, causing `FileNotFoundError` when OpenCompass was launched outside a source checkout root.

## Validation

- simulated wheel and sdist payloads include all three JSONL files
- loaded 1,685 MedBench entity choices from an unrelated working directory
- loaded both 96-sample LEval battle resources from an unrelated working directory
- Python 3.8 grammar check and relevant pre-commit hooks passed
- `git diff --check`
