### PR TITLE
Fix RJob failure propagation and submission logging

### DIFF
--- a/opencompass/runners/base.py
+++ b/opencompass/runners/base.py
@@ -37,7 +37,11 @@ class BaseRunner:
         """
         status = self.launch(tasks)
         status_list = list(status)  # change into list format
-        self.summarize(status_list)
+        failed_tasks = self.summarize(status_list)
+        if failed_tasks:
+            raise RuntimeError(
+                f'{len(failed_tasks)} task(s) failed: '
+                f'{", ".join(failed_tasks)}')
 
     @abstractmethod
     def launch(self, tasks: List[Dict[str, Any]]) -> List[Tuple[str, int]]:
@@ -51,7 +55,7 @@ class BaseRunner:
             list[tuple[str, int]]: A list of (task name, exit code).
         """
 
-    def summarize(self, status: List[Tuple[str, int]]) -> None:
+    def summarize(self, status: List[Tuple[str, int]]) -> List[str]:
         """Summarize the results of the tasks.
 
         Args:
@@ -82,3 +86,4 @@ class BaseRunner:
                 self.lark_reporter.post(title='Great news: all tasks '
                                         'finished!',
                                         content=content)
+        return failed_logs

--- a/opencompass/runners/rjob.py
+++ b/opencompass/runners/rjob.py
@@ -260,7 +260,14 @@ class RJOBRunner(BaseRunner):
                                         capture_output=True)
                 logger.info(f'CMD: {cmd}')
                 logger.info(f'Command output: {result.stdout}')
-                logger.error(f'Command error: {result.stderr}')
+                if result.returncode != 0:
+                    error_msg = (
+                        f'Command failed with return code {result.returncode}')
+                    if result.stderr:
+                        error_msg += f': {result.stderr}'
+                    logger.error(error_msg)
+                elif result.stderr:
+                    logger.warning(f'Command stderr: {result.stderr}')
                 logger.info(f'Return code: {result.returncode}')
                 if result.returncode == 0:
                     break
@@ -271,6 +278,7 @@ class RJOBRunner(BaseRunner):
             if result.returncode != 0:
                 # Submit failed, return directly
                 return task_name, result.returncode
+            logger.info(f'RJob submitted: {task_name}')
 
             # Submit successful, start polling
             status = self._run_task(task_name, out_path)

--- a/tests/runners/test_base.py
+++ b/tests/runners/test_base.py
@@ -1,0 +1,75 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / 'opencompass/runners/base.py'
+
+
+def _load_base_runner():
+    mmengine = types.ModuleType('mmengine')
+    mmengine_config = types.ModuleType('mmengine.config')
+    mmengine_config.Config = lambda task: SimpleNamespace(**task)
+    mmengine_config.ConfigDict = dict
+    mmengine.config = mmengine_config
+
+    opencompass = types.ModuleType('opencompass')
+    opencompass_utils = types.ModuleType('opencompass.utils')
+    opencompass_utils.LarkReporter = object
+    opencompass_utils.get_logger = lambda: SimpleNamespace(error=lambda *_: None)
+    opencompass.utils = opencompass_utils
+
+    stubs = {
+        'mmengine': mmengine,
+        'mmengine.config': mmengine_config,
+        'opencompass': opencompass,
+        'opencompass.utils': opencompass_utils,
+    }
+    previous = {name: sys.modules.get(name) for name in stubs}
+    sys.modules.update(stubs)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            'opencompass_runner_base', MODULE_PATH)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module.BaseRunner
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
+BaseRunner = _load_base_runner()
+
+
+class _FakeRunner(BaseRunner):
+
+    def __init__(self, status):
+        super().__init__(task={'type': 'fake'})
+        self.status = status
+
+    def launch(self, tasks):
+        return self.status
+
+
+class TestBaseRunner(unittest.TestCase):
+
+    def test_successful_tasks_return_normally(self):
+        runner = _FakeRunner([('task-a', 0), ('task-b', 0)])
+        runner([])
+
+    def test_failed_tasks_raise_runtime_error(self):
+        runner = _FakeRunner([('task-a', 0), ('task-b', 1)])
+
+        with self.assertRaisesRegex(RuntimeError, 'task-b'):
+            runner([])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- propagate non-zero runner task results so the OpenCompass process fails instead of only logging errors
- emit an explicit `RJob submitted` event only after `rjob submit` succeeds
- avoid logging an empty command error for successful submissions

This prevents planned RJob names whose submission failed from being interpreted as successfully completed jobs by external lifecycle integrations.

## Tests

- `python3 tests/runners/test_base.py`
- `python3 -m compileall -q opencompass/runners/base.py opencompass/runners/rjob.py tests/runners/test_base.py`
- `git diff --check`