### PR TITLE
[Fix] Avoid false error logs for successful RJob submissions

### DIFF
--- a/opencompass/runners/rjob.py
+++ b/opencompass/runners/rjob.py
@@ -260,7 +260,14 @@ class RJOBRunner(BaseRunner):
                                         capture_output=True)
                 logger.info(f'CMD: {cmd}')
                 logger.info(f'Command output: {result.stdout}')
-                logger.error(f'Command error: {result.stderr}')
+                if result.returncode != 0:
+                    error_msg = (
+                        f'Command failed with return code {result.returncode}')
+                    if result.stderr:
+                        error_msg += f': {result.stderr}'
+                    logger.error(error_msg)
+                elif result.stderr:
+                    logger.warning(f'Command stderr: {result.stderr}')
                 logger.info(f'Return code: {result.returncode}')
                 if result.returncode == 0:
                     break
@@ -271,6 +278,7 @@ class RJOBRunner(BaseRunner):
             if result.returncode != 0:
                 # Submit failed, return directly
                 return task_name, result.returncode
+            logger.info(f'RJob submitted: {task_name}')
 
             # Submit successful, start polling
             status = self._run_task(task_name, out_path)


### PR DESCRIPTION
## Motivation

`RJOBRunner` currently logs `subprocess.stderr` as an error even when the
submission command succeeds. Some successful RJob submissions therefore
produce misleading error logs.

There is also no explicit log marker emitted by the runner after the submission
command has completed successfully.

## Changes

- Log submission errors only when the command returns a non-zero exit code.
- Log non-empty stderr from successful commands as a warning.
- Emit `RJob submitted: <task_name>` after a successful submission.

## Compatibility

This change only improves logging and does not alter RJob execution or polling
behavior.

**Before PR**:
<img width="1720" height="60" alt="image" src="https://github.com/user-attachments/assets/861473df-cc65-4c4b-968c-e5dbf0e53351" />


**After PR**:
<img width="1155" height="97" alt="image" src="https://github.com/user-attachments/assets/5020f19b-c265-4f67-b165-9df4e0e16f4d" />


