### PR TITLE
Add multimodal C4 Bench evaluation

### DIFF
--- a/dataset-index.yml
+++ b/dataset-index.yml
@@ -1,3 +1,9 @@
+- c4_bench:
+    name: C4 Bench
+    category: Understanding
+    paper: https://arxiv.org/abs/2608.06501
+    configpath: opencompass/configs/datasets/c4_bench/c4_bench_gen.py
+    configpath_llmjudge: ''
 - ifeval:
     name: IFEval
     category: Instruction Following

--- a/docs/en/advanced_guides/custom_dataset.md
+++ b/docs/en/advanced_guides/custom_dataset.md
@@ -82,7 +82,8 @@ The format of multiple rounds and multiple modes datasets:
 ...
 ```
 
-(As OpenCompass currently does not support multi-mode evaluation, the template above is for reference only.)
+Structured multimodal messages are supported by model backends that accept
+image content, such as `LiteLLMAPI` configured with a vision-language model.
 
 When ChatMLDataset reading `.json` files, it will use `pydantic` to perform simple format validation on the files.
 You can use `tools/chatml_fformat_test.py` to check your provided data file.

--- a/docs/zh_cn/advanced_guides/custom_dataset.md
+++ b/docs/zh_cn/advanced_guides/custom_dataset.md
@@ -81,6 +81,9 @@ OpenCompass最新推出的基于ChatML对话模板的数据集评测模式，允
 ...
 ```
 
+支持图像内容的模型后端可以直接使用结构化多模态消息，例如配置视觉语言模型的
+`LiteLLMAPI`。
+
 `ChatMLDataset`在读取.jsonl文件时，会使用`pydantic`库对文件进行简易的格式校验。
 您可以使用`tools/chatml_format_test.py`对提供的数据文件进行检查。
 

--- a/opencompass/configs/datasets/c4_bench/README.md
+++ b/opencompass/configs/datasets/c4_bench/README.md
@@ -1,0 +1,33 @@
+# C4 Bench
+
+C4 Bench evaluates multimodal cross-concept creativity through Chinese
+chengyu. The primary configuration contains H0, H1, H4, and E0 (884 task
+rows); E1 is available through the task-specific configurations and is not
+included in the primary score.
+
+The loader reads task rows and images from
+[`sci-m-wang/C4-Eval`](https://huggingface.co/datasets/sci-m-wang/C4-Eval).
+Use an image-capable API model backend, such as `LiteLLMAPI` configured for a
+vision-language model. The dataset configuration does not override context or
+output length settings.
+
+```python
+from opencompass.configs.datasets.c4_bench.c4_bench_gen import c4_bench_datasets
+
+datasets = [*c4_bench_datasets]
+```
+
+## Citation
+
+```bibtex
+@misc{wang2026mllmsdecodecreativeleap,
+      title={Can MLLMs Decode the Creative Leap? Introducing C4 for Cross-Concept Understanding},
+      author={Ming Wang and Yuqing Zhang and Tingna Xie and Xiangju Li and
+              Xiaocui Yang and Daling Wang and Shi Feng and Yifei Zhang},
+      year={2026},
+      eprint={2608.06501},
+      archivePrefix={arXiv},
+      primaryClass={cs.AI},
+      url={https://arxiv.org/abs/2608.06501},
+}
+```

--- a/opencompass/configs/datasets/c4_bench/__init__.py
+++ b/opencompass/configs/datasets/c4_bench/__init__.py
@@ -1,0 +1,2 @@
+from .c4_bench_gen import c4_bench_datasets  # noqa: F401
+from .c4_bench_gen import c4_bench_task_datasets  # noqa: F401

--- a/opencompass/configs/datasets/c4_bench/c4_bench_gen.py
+++ b/opencompass/configs/datasets/c4_bench/c4_bench_gen.py
@@ -1,0 +1,35 @@
+from opencompass.datasets import C4BenchDataset, C4BenchEvaluator
+from opencompass.openicl.icl_inferencer import ChatMLInferencer
+from opencompass.openicl.icl_retriever import ZeroRetriever
+
+
+c4_bench_reader_cfg = dict(
+    input_columns=['question'],
+    output_column='reference',
+)
+
+
+def _c4_dataset(abbr, split):
+    return dict(
+        abbr=abbr,
+        type=C4BenchDataset,
+        path='sci-m-wang/C4-Eval',
+        split=split,
+        reader_cfg=c4_bench_reader_cfg,
+        infer_cfg=dict(
+            retriever=dict(type=ZeroRetriever),
+            inferencer=dict(type=ChatMLInferencer),
+        ),
+        eval_cfg=dict(
+            evaluator=dict(type=C4BenchEvaluator),
+            pred_role='BOT',
+        ),
+    )
+
+
+c4_bench_datasets = [_c4_dataset('C4-Bench', 'primary')]
+
+c4_bench_task_datasets = [
+    _c4_dataset(f'C4-Bench-{task}', task)
+    for task in ('H0', 'H1', 'H4', 'E0', 'E1')
+]

--- a/opencompass/datasets/__init__.py
+++ b/opencompass/datasets/__init__.py
@@ -22,6 +22,7 @@ from .boolq import *  # noqa: F401, F403
 from .bustum import *  # noqa: F401, F403
 from .BuySideFinBench import *  # noqa: F401, F403
 from .c3 import *  # noqa: F401, F403
+from .c4_bench import C4BenchDataset, C4BenchEvaluator  # noqa: F401
 from .calm import *  # noqa: F401, F403
 from .CARDBiomedBench import CARDBiomedBenchDataset  # noqa: F401
 from .cb import *  # noqa: F401, F403

--- a/opencompass/datasets/c4_bench.py
+++ b/opencompass/datasets/c4_bench.py
@@ -1,0 +1,221 @@
+"""C4 Bench dataset and evaluator.
+
+Paper: https://arxiv.org/abs/2608.06501
+Dataset: https://huggingface.co/datasets/sci-m-wang/C4-Eval
+
+Citation::
+
+    @misc{wang2026mllmsdecodecreativeleap,
+          title={Can MLLMs Decode the Creative Leap? Introducing C4 for
+                 Cross-Concept Understanding},
+          author={Ming Wang and Yuqing Zhang and Tingna Xie and Xiangju Li and
+                  Xiaocui Yang and Daling Wang and Shi Feng and Yifei Zhang},
+          year={2026},
+          eprint={2608.06501},
+          archivePrefix={arXiv},
+          primaryClass={cs.AI},
+          url={https://arxiv.org/abs/2608.06501},
+    }
+"""
+
+import json
+import os
+import re
+from typing import Dict, List, Optional, Tuple
+
+from datasets import Dataset, DatasetDict
+
+from opencompass.openicl.icl_evaluator.icl_base_evaluator import BaseEvaluator
+from opencompass.registry import ICL_EVALUATORS, LOAD_DATASET
+
+from .base import BaseDataset
+
+DEFAULT_REPO_ID = 'sci-m-wang/C4-Eval'
+DEFAULT_DATA_FILENAME = 'data/eval.jsonl'
+PRIMARY_TASKS = ('H0', 'H1', 'H4', 'E0')
+EXPLANATION_TASKS = ('E0', 'E1')
+TASK_SPLITS = {
+    'primary': PRIMARY_TASKS,
+    'all': (*PRIMARY_TASKS, 'E1'),
+    'H0': ('H0', ),
+    'H1': ('H1', ),
+    'H4': ('H4', ),
+    'E0': ('E0', ),
+    'E1': ('E1', ),
+}
+
+PUNCT_RE = re.compile(r'[\s\n\r\t，,。.!！?？:：;；、\'"“”‘’`·]+')
+ANSWER_PATTERNS = (
+    re.compile(
+        r'["\']?answer["\']?\s*[:：]\s*["“”\']?([\u4e00-\u9fff]{4})',
+        re.IGNORECASE,
+    ),
+    re.compile(r'(?:答案|成语)\s*(?:是|为|[:：])\s*["“”\']?([\u4e00-\u9fff]{4})'),
+)
+
+
+def normalize_c4_answer(text: str) -> str:
+    return PUNCT_RE.sub('', str(text or '')).strip()
+
+
+def _strip_code_fence(text: str) -> str:
+    cleaned = str(text or '').strip()
+    if cleaned.startswith('```'):
+        cleaned = re.sub(r'^```(?:json)?\s*', '', cleaned)
+        cleaned = re.sub(r'\s*```$', '', cleaned)
+    return cleaned.strip()
+
+
+def _recover_explicit_answer(text: str) -> str:
+    for pattern in ANSWER_PATTERNS:
+        matches = pattern.findall(str(text or ''))
+        if matches:
+            return matches[-1]
+    lines = [
+        line.strip().strip('"“”') for line in str(text or '').splitlines()
+        if line.strip()
+    ]
+    if lines and re.fullmatch(r'[\u4e00-\u9fff]{4}', lines[-1]):
+        return lines[-1]
+    return ''
+
+
+def parse_c4_answer(task: str, output: str) -> Tuple[str, Optional[bool]]:
+    if task in EXPLANATION_TASKS:
+        try:
+            parsed = json.loads(_strip_code_fence(output))
+        except (json.JSONDecodeError, TypeError):
+            return _recover_explicit_answer(output), False
+        if not isinstance(parsed, dict):
+            return '', False
+        return str(parsed.get('answer', '')).strip(), True
+
+    lines = [
+        line.strip() for line in str(output or '').splitlines()
+        if line.strip()
+    ]
+    if len(lines) == 1:
+        answer = lines[0].strip('"“”')
+    else:
+        answer = _recover_explicit_answer(output)
+    return answer, None
+
+
+def _resolve_data_file(path: str, data_filename: str) -> str:
+    if os.path.isfile(path):
+        return path
+    if os.path.isdir(path):
+        local_path = os.path.join(path, data_filename)
+        if os.path.isfile(local_path):
+            return local_path
+
+    from huggingface_hub import hf_hub_download
+    return hf_hub_download(
+        repo_id=path,
+        filename=data_filename,
+        repo_type='dataset',
+    )
+
+
+@LOAD_DATASET.register_module()
+class C4BenchDataset(BaseDataset):
+    """Load C4 task rows as structured multimodal ChatML messages."""
+
+    @staticmethod
+    def load(path: str = DEFAULT_REPO_ID,
+             data_filename: str = DEFAULT_DATA_FILENAME,
+             split: str = 'primary') -> DatasetDict:
+        if split not in TASK_SPLITS:
+            raise ValueError(f'Unsupported C4 Bench split: {split}')
+
+        data_path = _resolve_data_file(path, data_filename)
+        with open(data_path, encoding='utf-8') as file:
+            rows = [json.loads(line) for line in file if line.strip()]
+
+        selected = []
+        for row in rows:
+            if row['task'] not in TASK_SPLITS[split]:
+                continue
+            reference = {
+                'task': row['task'],
+                'answer': row['answer'],
+                'answer_aliases': row.get('answer_aliases', []),
+            }
+            selected.append({
+                'instance_id':
+                row['instance_id'],
+                'task':
+                row['task'],
+                'question':
+                row['question'],
+                'answer':
+                row['answer'],
+                'reference':
+                reference,
+                'chatml_question': [{
+                    'role':
+                    'user',
+                    'content': [
+                        {
+                            'type': 'image',
+                            'image_url': row['image'],
+                        },
+                        {
+                            'type': 'text',
+                            'text': row['question'],
+                        },
+                    ],
+                }],
+                'chatml_answer': [row['answer']],
+            })
+
+        dataset = Dataset.from_list(selected)
+        return DatasetDict({'test': dataset, 'train': dataset})
+
+
+@ICL_EVALUATORS.register_module()
+class C4BenchEvaluator(BaseEvaluator):
+    """Official exact-recovery and JSON-validity metrics for C4 Bench."""
+
+    def score(self, predictions: List[str], references: List[Dict]) -> Dict:
+        if len(predictions) != len(references):
+            return {
+                'error': 'predictions and references have different length'
+            }
+
+        records = []
+        for prediction, reference in zip(predictions, references):
+            task = str(reference['task'])
+            parsed, json_valid = parse_c4_answer(task, prediction)
+            aliases = reference.get('answer_aliases', []) or []
+            accepted = {
+                normalize_c4_answer(answer)
+                for answer in [reference['answer'], *aliases]
+                if normalize_c4_answer(answer)
+            }
+            records.append({
+                'task': task,
+                'exact': normalize_c4_answer(parsed) in accepted,
+                'json_valid': json_valid,
+            })
+
+        metrics: Dict[str, float] = {}
+        primary = [
+            record for record in records if record['task'] in PRIMARY_TASKS
+        ]
+        if primary:
+            metrics['Primary Score'] = 100 * sum(
+                record['exact'] for record in primary) / len(primary)
+
+        for task in TASK_SPLITS['all']:
+            subset = [record for record in records if record['task'] == task]
+            if not subset:
+                continue
+            if task != 'E1':
+                metrics[f'{task} Exact Match'] = 100 * sum(
+                    record['exact'] for record in subset) / len(subset)
+            if task in EXPLANATION_TASKS:
+                metrics[f'{task} JSON Valid'] = 100 * sum(
+                    bool(record['json_valid'])
+                    for record in subset) / len(subset)
+        return metrics

--- a/opencompass/models/litellm_api.py
+++ b/opencompass/models/litellm_api.py
@@ -128,7 +128,26 @@ class LiteLLMAPI(BaseAPIModel):
         self.flush()
         return results
 
-    def _build_messages(self, input: PromptType) -> List[Dict[str, str]]:
+    @staticmethod
+    def _normalize_content(content: Any) -> Any:
+        if not isinstance(content, list):
+            return content
+
+        normalized = []
+        for item in content:
+            if not isinstance(item, dict) or item.get('type') != 'image':
+                normalized.append(item)
+                continue
+            image_url = item.get('image_url', '')
+            if isinstance(image_url, str):
+                image_url = {'url': image_url}
+            normalized.append({
+                'type': 'image_url',
+                'image_url': image_url,
+            })
+        return normalized
+
+    def _build_messages(self, input: PromptType) -> List[Dict[str, Any]]:
         """Convert an OpenCompass input into OpenAI-shaped messages.
 
         Handles three cases:
@@ -149,8 +168,11 @@ class LiteLLMAPI(BaseAPIModel):
                 and item['role'] in CHATML_ROLE for item in input)):
             # Already CHATML-shaped, assume ``content`` key is populated.
             messages = [{
-                'role': item['role'],
-                'content': item.get('content', item.get('prompt', '')),
+                'role':
+                item['role'],
+                'content':
+                self._normalize_content(
+                    item.get('content', item.get('prompt', ''))),
             } for item in input]
         else:
             messages = []
@@ -162,7 +184,8 @@ class LiteLLMAPI(BaseAPIModel):
                     messages.append({'role': 'user', 'content': item})
                     continue
                 role = item.get('role', '')
-                content = item.get('prompt', item.get('content', ''))
+                content = self._normalize_content(
+                    item.get('prompt', item.get('content', '')))
                 if role == 'HUMAN':
                     messages.append({'role': 'user', 'content': content})
                 elif role == 'BOT':
@@ -182,19 +205,29 @@ class LiteLLMAPI(BaseAPIModel):
 
         return messages
 
-    def _get_messages_token_len(self, messages: List[Dict[str, str]]) -> int:
-        return sum(
-            self.get_token_len(str(message.get('content', '')))
-            for message in messages)
+    def _get_messages_token_len(self, messages: List[Dict[str, Any]]) -> int:
+        text_segments = []
+        for message in messages:
+            content = message.get('content', '')
+            if isinstance(content, list):
+                text_segments.extend(
+                    str(item.get('text', '')) for item in content
+                    if isinstance(item, dict) and item.get('type') == 'text')
+            else:
+                text_segments.append(str(content))
+        return sum(self.get_token_len(text) for text in text_segments)
 
-    def _adjust_max_out_len(self, messages: List[Dict[str, str]],
-                            max_out_len: int) -> int:
+    def _adjust_max_out_len(self, messages: List[Dict[str, Any]],
+                            max_out_len: Optional[int]) -> Optional[int]:
         input_len = self._get_messages_token_len(messages)
         if input_len > self.max_seq_len:
             raise ValueError(
                 f'Input length ({input_len}) exceeds max_seq_len '
                 f'({self.max_seq_len}). Please increase max_seq_len or '
                 'shorten the prompt.')
+
+        if max_out_len is None:
+            return None
 
         available_out_len = (self.max_seq_len - input_len -
                              RESERVED_OUTPUT_TOKENS)
@@ -213,8 +246,8 @@ class LiteLLMAPI(BaseAPIModel):
         return adjusted_max_out_len
 
     def _build_call_kwargs(self,
-                           messages: List[Dict[str, str]],
-                           max_out_len: int,
+                           messages: List[Dict[str, Any]],
+                           max_out_len: Optional[int],
                            gen_kwargs: Optional[Dict] = None) -> Dict:
         gen_kwargs = gen_kwargs or {}
         blocked_kwargs = sorted(set(gen_kwargs) & CORE_CALL_KWARGS)
@@ -236,9 +269,10 @@ class LiteLLMAPI(BaseAPIModel):
             **safe_gen_kwargs,
             'model': self.path,
             'messages': messages,
-            'max_tokens': max_out_len,
             'drop_params': True,
         }
+        if max_out_len is not None:
+            call_kwargs['max_tokens'] = max_out_len
         if self.temperature is not None:
             call_kwargs['temperature'] = self.temperature
         if self.key is not None:
@@ -302,7 +336,7 @@ class LiteLLMAPI(BaseAPIModel):
 
     def _generate(self,
                   input: PromptType,
-                  max_out_len: int,
+                  max_out_len: Optional[int],
                   gen_kwargs: Optional[Dict] = None) -> str:
         try:
             import litellm

--- a/opencompass/openicl/icl_inferencer/icl_chatml_inferencer.py
+++ b/opencompass/openicl/icl_inferencer/icl_chatml_inferencer.py
@@ -27,7 +27,7 @@ class ChatMLInferencer(BaseInferencer):
     def __init__(
             self,
             model: BaseModel,
-            max_out_len: int,
+            max_out_len: Optional[int] = None,
             stopping_criteria: List[str] = [],
             max_seq_len: Optional[int] = None,
             min_out_len: Optional[int] = None,
@@ -67,9 +67,16 @@ class ChatMLInferencer(BaseInferencer):
         get_prompt_list = (
             self.get_generation_prompt_list_from_retriever_indices)
         for i in range(len(origin_prompt)):
+            chatml_question = origin_prompt['chatml_question'][i]
+            if any(
+                    isinstance(message.get('content'), list)
+                    for message in chatml_question):
+                prompt_list.append(chatml_question)
+                continue
+
             new_prompt_template = dict()
             new_prompt_template['round'] = []
-            for question_round in origin_prompt['chatml_question'][i]:
+            for question_round in chatml_question:
                 if question_round['role'] == 'system':
                     this_system_prompt = question_round['content']
                     new_prompt_template['begin'] = [

--- a/opencompass/openicl/icl_inferencer/icl_chatml_inferencer_parallel.py
+++ b/opencompass/openicl/icl_inferencer/icl_chatml_inferencer_parallel.py
@@ -27,7 +27,7 @@ class ParallelChatMLInferencer(ChatMLInferencer):
     def __init__(
             self,
             model,
-            max_out_len: int,
+            max_out_len: Optional[int] = None,
             stopping_criteria: List[str] = [],
             max_seq_len: Optional[int] = None,
             min_out_len: Optional[int] = None,

--- a/tests/datasets/test_c4_bench.py
+++ b/tests/datasets/test_c4_bench.py
@@ -1,0 +1,67 @@
+import json
+
+from opencompass.datasets.c4_bench import (C4BenchDataset,
+                                           C4BenchEvaluator,
+                                           parse_c4_answer)
+
+
+def _row(task, instance_id):
+    return {
+        'instance_id': instance_id,
+        'task': task,
+        'question': '请回答成语。',
+        'answer': '一叶障目',
+        'answer_aliases': [],
+        'image': 'https://example.com/image.png',
+    }
+
+
+def test_c4_loader_filters_primary_tasks_and_builds_multimodal_chatml(
+        tmp_path):
+    data_path = tmp_path / 'eval.jsonl'
+    rows = [_row('H0', 'item__H0'), _row('E1', 'item__E1')]
+    data_path.write_text(
+        '\n'.join(json.dumps(row, ensure_ascii=False) for row in rows),
+        encoding='utf-8',
+    )
+
+    dataset = C4BenchDataset.load(path=str(data_path), split='primary')['test']
+
+    assert len(dataset) == 1
+    content = dataset[0]['chatml_question'][0]['content']
+    assert content[0]['type'] == 'image'
+    assert content[0]['image_url'] == 'https://example.com/image.png'
+    assert content[1]['text'] == '请回答成语。'
+
+
+def test_c4_evaluator_uses_official_primary_denominator():
+    evaluator = C4BenchEvaluator()
+    references = [
+        {
+            'task': 'H0',
+            'answer': '一叶障目',
+            'answer_aliases': [],
+        },
+        {
+            'task': 'E0',
+            'answer': '一叶障目',
+            'answer_aliases': [],
+        },
+        {
+            'task': 'E1',
+            'answer': '一叶障目',
+            'answer_aliases': [],
+        },
+    ]
+    predictions = [
+        '一叶障目',
+        '{"answer": "错误答案", "explanation": "..."}',
+        '{"answer": "一叶障目", "explanation": "..."}',
+    ]
+
+    scores = evaluator.score(predictions, references)
+
+    assert scores['Primary Score'] == 50
+    assert scores['E0 JSON Valid'] == 100
+    assert scores['E1 JSON Valid'] == 100
+    assert parse_c4_answer('E0', '最终答案：一叶障目') == ('一叶障目', False)

--- a/tests/models/test_litellm_api.py
+++ b/tests/models/test_litellm_api.py
@@ -95,6 +95,14 @@ class TestLiteLLMAPIInit(unittest.TestCase):
         self.assertNotIn('api_version', kwargs)
         self.assertNotIn('temperature', kwargs)
 
+    def test_call_kwargs_omits_max_tokens_when_unset(self):
+        model = LiteLLMAPI(path='openai/gpt-4o-mini')
+        kwargs = model._build_call_kwargs(
+            messages=[{'role': 'user', 'content': 'hi'}],
+            max_out_len=None,
+        )
+        self.assertNotIn('max_tokens', kwargs)
+
     def test_drop_params_default_true(self):
         model = LiteLLMAPI(path='openai/gpt-4o-mini')
         kwargs = model._build_call_kwargs(
@@ -251,6 +259,30 @@ class TestLiteLLMAPIMessages(unittest.TestCase):
         ]
         messages = model._build_messages(chatml)
         self.assertEqual(messages, chatml)
+
+    def test_multimodal_chatml_normalizes_image_content(self):
+        model = LiteLLMAPI(path='openai/gpt-4o-mini')
+        chatml = [{
+            'role': 'user',
+            'content': [
+                {
+                    'type': 'image',
+                    'image_url': 'https://example.com/image.png',
+                },
+                {
+                    'type': 'text',
+                    'text': 'What is shown?',
+                },
+            ],
+        }]
+        messages = model._build_messages(chatml)
+        self.assertEqual(messages[0]['content'][0], {
+            'type': 'image_url',
+            'image_url': {
+                'url': 'https://example.com/image.png'
+            },
+        })
+        self.assertEqual(model._get_messages_token_len(messages), 3)
 
     def test_system_prompt_prepended_when_absent(self):
         model = LiteLLMAPI(path='openai/gpt-4o-mini',

--- a/tests/openicl/test_icl_chatml_inferencer_parallel.py
+++ b/tests/openicl/test_icl_chatml_inferencer_parallel.py
@@ -41,6 +41,44 @@ class TestParallelChatMLInferencer(unittest.TestCase):
         self.assertIsNone(inferencer.max_infer_workers)
         self.assertIsNone(inferencer.progress_tracker)
 
+    def test_multimodal_messages_are_forwarded_without_flattening(self):
+        inferencer = ParallelChatMLInferencer(model=self.mock_model)
+        messages = [{
+            'role':
+            'user',
+            'content': [
+                {
+                    'type': 'image',
+                    'image_url': 'https://example.com/image.png',
+                },
+                {
+                    'type': 'text',
+                    'text': 'Question',
+                },
+            ],
+        }]
+        retriever = MagicMock()
+        retriever.retrieve.return_value = [[0]]
+
+        class _OriginPrompt:
+
+            def __len__(self):
+                return 1
+
+            def __getitem__(self, key):
+                return {
+                    'chatml_question': [messages],
+                    'chatml_answer': [['answer']],
+                }[key]
+
+        retriever.dataset_reader = {'test': _OriginPrompt()}
+
+        prompts, answers = inferencer._get_prompt_list_and_gold_ans(retriever)
+
+        self.assertEqual(prompts, [messages])
+        self.assertEqual(answers, ['answer'])
+        self.assertIsNone(inferencer.max_out_len)
+
     def test_resolve_max_workers_from_config(self):
         """Test _resolve_max_workers uses max_infer_workers."""
         inferencer = ParallelChatMLInferencer(model=self.mock_model,


### PR DESCRIPTION
## Motivation

Add C4 Bench, an image-text-to-text benchmark for cross-concept creative understanding through Chinese chengyu. The paper and public task rows are available at:

- Paper: https://arxiv.org/abs/2608.06501
- Dataset: https://huggingface.co/datasets/sci-m-wang/C4-Eval

## Modification

- add the C4 dataset loader, official exact-recovery evaluator, primary and task-specific configs, dataset index entry, and complete BibTeX citation
- load structured image/text ChatML messages from Hugging Face
- forward multimodal ChatML messages without flattening them to strings
- normalize OpenCompass image items to OpenAI/LiteLLM `image_url` content
- allow ChatML inference to leave output length unset; `LiteLLMAPI` omits `max_tokens` when no value is configured
- update the English and Chinese custom-dataset documentation and add focused tests

The official C4 primary score uses exact recovery over H0, H1, H4, and E0 (884 rows). E1 is available separately and is excluded from the primary denominator.

## BC-breaking (Optional)

No. Existing text-only ChatML behavior and explicitly configured output lengths are unchanged.

## Use cases (Optional)

```python
from opencompass.configs.datasets.c4_bench.c4_bench_gen import c4_bench_datasets

datasets = [*c4_bench_datasets]
```

Use an image-capable API backend such as `LiteLLMAPI` configured for a vision-language model. The C4 dataset config does not override model context or output length settings.

## Testing

- flake8, isort, YAPF, YAML, compilation, and whitespace checks pass
- isolated end-to-end checks against the public 1,105-row file confirm 884 primary rows, structured image forwarding, official scoring, and omission of `max_tokens` when unset
- focused dataset, evaluator, ChatML, and LiteLLM tests are included; the local environment lacked `torch` and `datasets`, so the complete pytest run is left to CI

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
