### PR TITLE
[Fix] Fix EESE scoring of worded judge replies

### DIFF
--- a/opencompass/datasets/eese/eese_postprocessors.py
+++ b/opencompass/datasets/eese/eese_postprocessors.py
@@ -18,10 +18,10 @@ def eese_score_postprocess_dict(output: dict, output_path: str) -> dict:
             else:
                 # 如果没有找到数字，尝试解析其他格式
                 prediction_lower = prediction.strip().lower()
-                if 'correct' in prediction_lower or 'right' in prediction_lower or '10' in prediction_lower:
-                    value['score'] = 10
-                elif 'incorrect' in prediction_lower or 'wrong' in prediction_lower or '0' in prediction_lower:
+                if 'incorrect' in prediction_lower or 'wrong' in prediction_lower:
                     value['score'] = 0
+                elif 'correct' in prediction_lower or 'right' in prediction_lower:
+                    value['score'] = 10
                 else:
                     value['score'] = 0  # 默认返回0分
 

--- a/opencompass/datasets/eese/utils.py
+++ b/opencompass/datasets/eese/utils.py
@@ -25,7 +25,7 @@ def extract_first_numeric_score(score_text):
 
         if match:
             return int(match.group())
-        return 0
+        return None
 
 
 def process_results(results, overall_avg):

--- a/tests/datasets/test_eese.py
+++ b/tests/datasets/test_eese.py
@@ -1,0 +1,31 @@
+import unittest
+
+from opencompass.datasets.eese.eese_postprocessors import \
+    eese_score_postprocess_dict
+from opencompass.datasets.eese.utils import extract_first_numeric_score
+
+
+class TestExtractFirstNumericScore(unittest.TestCase):
+
+    def test_score_is_read_from_surrounding_text(self):
+        self.assertEqual(extract_first_numeric_score('Score: 7'), 7)
+
+    def test_text_without_digits_has_no_score(self):
+        self.assertIsNone(extract_first_numeric_score('Correct'))
+
+
+class TestEESEScorePostprocess(unittest.TestCase):
+
+    def score_of(self, prediction):
+        output = {'q1': {'prediction': prediction}}
+        result = eese_score_postprocess_dict(output, '')
+        return result['details']['q1']['score']
+
+    def test_worded_verdicts_are_graded_by_keyword(self):
+        self.assertEqual(self.score_of('Correct'), 10)
+        self.assertEqual(self.score_of('Incorrect'), 0)
+        self.assertEqual(self.score_of('no verdict given'), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation

`eese_score_postprocess_dict` reads the judge's reply with
`extract_first_numeric_score` and gates on `if score is not None`, falling back to a
keyword branch otherwise. The docstring of `extract_first_numeric_score` says it
returns None when it finds no number; it returns 0. For any non-empty reply the gate
holds, so the keyword branch is unreachable and a judge that answers `Correct` rather
than `10` is recorded as 0 out of 10:

```
reply='Correct'                extract=0    score=0   overall=0.0
reply='The answer is correct'  extract=0    score=0   overall=0.0
reply='Right'                  extract=0    score=0   overall=0.0
reply='incorrect'              extract=0    score=0   overall=0.0
reply='Score: 7'               extract=7    score=7   overall=0.7
```

The keyword branch carries a second defect that only shows once it can run:
`'correct' in prediction_lower` also matches `incorrect`, and it is tested before the
negative wording, so `Incorrect` would score 10. Returning None on its own turns a
false zero into a false ten:

```
reply='Correct'                extract=None score=10  overall=1.0
reply='incorrect'              extract=None score=10  overall=1.0
```

Both need fixing together.

### Modification

- `extract_first_numeric_score` returns None for text that holds no digits, which is
  what its docstring already documents.
- The keyword branch tests `incorrect`/`wrong` before `correct`/`right`.
- The `'10' in ...` and `'0' in ...` substring tests are dropped from that branch. It
  is entered only when the reply holds no digit at all, so neither can ever match.
- `tests/datasets/test_eese.py` covers the None contract and the three keyword
  outcomes.

### BC-breaking (Optional)

Scores change for judge replies that contain no digits. `Correct` moves from 0 to 10;
`Incorrect`, `wrong` and unrecognised text stay at 0. Replies that carry a number,
which is what `GRADER_TEMPLATE` asks for, are unaffected. Any past EESE run scored by
a judge that answered in words was reported too low, and its `overall_score` will rise
on a re-run.

### Use cases (Optional)

Not applicable.

### Tests

- `pytest tests/datasets/test_eese.py -q` — 3 passed. On `main`, two of the three fail
  (`AssertionError: 0 is not None` and `AssertionError: 0 != 10`).
- `pytest tests/datasets tests/openicl tests/utils tests/evaluator
  --ignore=tests/datasets/test_local_datasets.py -q` — 3 failed, 163 passed, 2 skipped;
  the three failures are the pre-existing `test_livecodebench_evaluator` cases.
- `pre-commit run --files opencompass/datasets/eese/utils.py
  opencompass/datasets/eese/eese_postprocessors.py tests/datasets/test_eese.py` —
  flake8, isort, yapf and codespell pass.

### Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
