### PR TITLE
[Fix] Fix broken Star History chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ English | [简体中文](README_zh-CN.md)
 <details>
   <summary><kbd>Star History</kbd></summary>
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=open-compass%2Fopencompass&theme=dark&type=Date">
-    <img width="100%" src="https://api.star-history.com/svg?repos=open-compass%2Fopencompass&type=Date">
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=open-compass%2Fopencompass&theme=dark&type=Date">
+    <img width="100%" src="https://star-history.dera.page/svg?repos=open-compass%2Fopencompass&type=Date">
   </picture>
 </details>
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -37,8 +37,8 @@
 <details>
   <summary><kbd>Star History</kbd></summary>
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=open-compass%2Fopencompass&theme=dark&type=Date">
-    <img width="100%" src="https://api.star-history.com/svg?repos=open-compass%2Fopencompass&type=Date">
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=open-compass%2Fopencompass&theme=dark&type=Date">
+    <img width="100%" src="https://star-history.dera.page/svg?repos=open-compass%2Fopencompass&type=Date">
   </picture>
 </details>
 


### PR DESCRIPTION
The Star History chart shown in the README is currently broken due to GitHub stargazer API restrictions, so the star count graph no longer renders. This PR points the chart at the star-history.dera.page endpoint, which uses an alternative data source that requires no API token, restoring the chart in both the English and Chinese README files.