### PR TITLE
fix(datasets): anchored grade extraction + surface judge failures in generic llmjudge

### DIFF
--- a/opencompass/datasets/generic.py
+++ b/opencompass/datasets/generic.py
@@ -3,6 +3,20 @@ import re
 from opencompass.registry import DICT_POSTPROCESSORS
 from opencompass.utils import get_logger
 
+# Anchored grade marker: a grade cue word immediately followed by a connector
+# and the grade letter. Cues are deliberately narrow (grade/verdict/final
+# answer) — bare "answer" is excluded because "the answer is A" names the
+# *option*, not the grade; only "final answer" is unambiguous. A connector is
+# required so bare prose like "grade A of this study" (a quality qualifier)
+# cannot be mistaken for a grade. Connector grammar covers both word forms
+# ("grade is B", "grade of A", "final answer is: B") and symbol forms
+# ("grade: B", "grade = B", "grade:=B").
+_ANCHORED_GRADE_RE = re.compile(
+    r'\b(?:grade|verdict|final\s+answer)\s*'
+    r'(?:(?:is|was|be|of)\s*[:=]?|[:=]{1,2})'
+    r'\s*[(\[]?\s*([AB])\s*[)\]]?',
+    re.IGNORECASE)
+
 
 def get_final_results(judged_answers,
                       references,
@@ -14,6 +28,7 @@ def get_final_results(judged_answers,
     is_correct_count = 0
     is_incorrect_count = 0
     is_not_attempted_count = 0
+    is_judge_error_count = 0
     attempted_judge_count = 0
     details = []
     for i, j, k in zip(judged_answers, references, origial_responses):
@@ -33,6 +48,15 @@ def get_final_results(judged_answers,
             detail['correct'] = True
         elif grade_letter == false_tag:
             is_incorrect_count += 1
+        elif grade_letter == 'unknown':
+            # The judge did not emit a usable grade. This is a *failure* of the
+            # judge, surfaced separately so it cannot be silently read as a
+            # wrong answer. It is still counted in not_attempted_count (as
+            # upstream did) so every existing aggregate keeps its historical
+            # meaning; judge_error_count is purely additive observability.
+            is_judge_error_count += 1
+            detail['judge_error'] = True
+            is_not_attempted_count += 1
         else:
             is_not_attempted_count += 1
         details.append(detail)
@@ -55,6 +79,7 @@ def get_final_results(judged_answers,
         'correct_count': is_correct_count,
         'incorrect_count': is_incorrect_count,
         'not_attempted_count': is_not_attempted_count,
+        'judge_error_count': is_judge_error_count,
         'details': details,
     }
     return result
@@ -63,6 +88,13 @@ def get_final_results(judged_answers,
 def _generic_llmjudge_postprocess(judgement: str,
                                   true_tag: str = 'A',
                                   false_tag: str = 'B'):
+    # Single-direction conservative fix: only an explicitly anchored grade
+    # ("grade: B", "grade is B", "final answer = A") is trusted. Everything
+    # else keeps the legacy loose scan, so no judge reply that used to parse
+    # now becomes an error (no regression, no silently-dropped samples).
+    anchored = _ANCHORED_GRADE_RE.search(judgement)
+    if anchored:
+        return anchored.group(1).upper()
     match = re.search(rf'({re.escape(true_tag)}|{re.escape(false_tag)})',
                       judgement)
     grade_letter = match.group(0) if match else 'unknown'

--- a/tests/datasets/test_generic_llmjudge_postprocess.py
+++ b/tests/datasets/test_generic_llmjudge_postprocess.py
@@ -1,0 +1,115 @@
+"""Tests for the LLM judge postprocessor in opencompass/datasets/generic.py.
+
+These cover the anchored-grade extraction (a judge's free-text reply may name
+non-grade things that look like letters) and the aggregation contract (judge
+failures are surfaced, never silently absorbed into accuracy).
+
+Design intent: the *anchored* grade ("grade is B", "grade: B", "final answer
+is: B", "grade of A") is the only thing trusted when it is present. Everything
+else falls back to the historical loose scan so no previously-parseable judge
+reply regresses to 'unknown'. Bare qualifiers ("grade A of this study") and
+bare option labels ("the answer is A") must never be mistaken for a grade.
+"""
+
+import unittest
+
+from opencompass.datasets.generic import (
+    _generic_llmjudge_postprocess,
+    get_final_results,
+)
+
+
+class TestGenericLlmJudgeGradeExtraction(unittest.TestCase):
+    """Anchored grades are extracted even when prose letters precede them."""
+
+    def test_prose_first_letter_no_longer_wins(self):
+        # Upstream regex took the first A/B in the reply; here the prose
+        # letter 'A' must lose to the anchored "grade is B".
+        self.assertEqual(
+            _generic_llmjudge_postprocess(
+                'As a judge, I considered the evidence carefully. '
+                'The final grade is B.'),
+            'B')
+
+    def test_anchored_colon_grade(self):
+        self.assertEqual(
+            _generic_llmjudge_postprocess(
+                'The answer is incorrect, grade: B. Summary: A clear miss.'),
+            'B')
+
+    def test_anchored_grade_is(self):
+        self.assertEqual(
+            _generic_llmjudge_postprocess(
+                'The response is labeled letter A, but it should be marked '
+                'incorrect, so the grade is B.'),
+            'B')
+
+    def test_anchored_final_answer_colon(self):
+        self.assertEqual(
+            _generic_llmjudge_postprocess('The final answer is: B'), 'B')
+
+    def test_anchored_grade_of(self):
+        self.assertEqual(
+            _generic_llmjudge_postprocess('I give the response a grade of A.'),
+            'A')
+
+    def test_anchored_grade_equals(self):
+        self.assertEqual(_generic_llmjudge_postprocess('grade = A'), 'A')
+
+    def test_anchored_verdict(self):
+        self.assertEqual(
+            _generic_llmjudge_postprocess('My verdict is B.'), 'B')
+
+    def test_exact_letter_still_accepted(self):
+        self.assertEqual(_generic_llmjudge_postprocess('A'), 'A')
+        self.assertEqual(_generic_llmjudge_postprocess('  B  '), 'B')
+
+    def test_no_letter_is_unknown(self):
+        self.assertEqual(_generic_llmjudge_postprocess('CORRECT'), 'unknown')
+
+
+class TestGenericLlmJudgeNoFalseAnchor(unittest.TestCase):
+    """Qualifiers and option labels must not be mistaken for a grade."""
+
+    def test_grade_a_of_is_qualifier_not_grade(self):
+        # "grade A of the study" is a quality qualifier, not an assignment.
+        # The real verdict is the anchored "verdict is B".
+        self.assertEqual(
+            _generic_llmjudge_postprocess(
+                'This is grade A of the study quality, the verdict is B.'),
+            'B')
+
+    def test_bare_answer_is_a_option_not_grade(self):
+        # "the answer is A" names the option; the grade is anchored later.
+        self.assertEqual(
+            _generic_llmjudge_postprocess(
+                'The answer is A, and the model is correct, so the grade is B.'),
+            'B')
+
+
+class TestGenericLlmJudgeAggregation(unittest.TestCase):
+    """get_final_results surfaces judge failures without shifting semantics."""
+
+    def test_unknown_is_surfaced_and_keeps_not_attempted_semantics(self):
+        judged = ['A', 'A', 'A', 'A', 'B',
+                  'unknown', 'unknown', 'unknown', 'B', 'A']
+        res = get_final_results(judged, ['r'] * 10, ['p'] * 10)
+        # 5 correct / 10 total — accuracy semantics unchanged from upstream.
+        self.assertEqual(res['accuracy'], 50.0)
+        # upstream counted 'unknown' as not_attempted; keep that, and ADD the
+        # judge-failure surface so failures cannot be read as wrong answers.
+        self.assertEqual(res['not_attempted_count'], 3)
+        self.assertEqual(res['judge_error_count'], 3)
+        for detail in res['details']:
+            is_unknown = detail['grade_letter'] == 'unknown'
+            self.assertEqual('judge_error' in detail, is_unknown)
+
+    def test_no_judge_error_when_all_graded(self):
+        judged = ['A', 'B', 'A', 'B', 'A']
+        res = get_final_results(judged, ['r'] * 5, ['p'] * 5)
+        self.assertEqual(res['judge_error_count'], 0)
+        self.assertEqual(res['accuracy'], 60.0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Motivation

`_generic_llmjudge_postprocess` scans the judge's free-text reply for the first `A`/`B` anywhere in it. Judges routinely justify their verdict before stating it, so a reasoning sentence that merely *contains* a letter silently overrides the real grade ("As a judge, I considered the evidence carefully. The final grade is B." parses as `A`). Separately, when a judge fails to emit a usable grade (API error, truncation, no letter in the reply), the result degrades to `'unknown'`, which `get_final_results` folds into the accuracy denominator — indistinguishable from a genuine wrong answer. Related upstream reports: #1232, #2522, #2392.

## The fix (two parts)

### 1. Anchored grade extraction (no regression)

Only a grade that is *explicitly anchored* is trusted: a cue word (`grade`, `verdict`, `final answer`) immediately followed by a connector (`is` / `was` / `be` / `of` / `:` / `=` / `:=`) and the letter. Everything else keeps the existing loose scan, so every judge reply that previously parsed still parses (zero recall regression, no silently-dropped samples).

Deliberate exclusions, each with a regression test:
- bare `answer` is **not** a cue — "the answer is A" names the *option*, not the grade;
- a connector is **required** — "grade A of this study" is a quality qualifier, not an assignment.

### 2. Judge failures are surfaced, not absorbed

`get_final_results` now counts judge failures separately (`judge_error_count`, plus a `judge_error` flag on each failing detail), while `accuracy`, `accuracy_given_attempted`, `not_attempted_count`, and friends keep their exact historical semantics (`unknown` still counts as not-attempted). A judge failure can no longer be silently read as a wrong answer.

## Tests

`tests/datasets/test_generic_llmjudge_postprocess.py` — 13 cases covering anchored extraction, the anti-false-anchor contract, and the aggregation surface. Follows `tests/TESTING_GUIDE.md` conventions.

## Impact on existing results

This fix changes how judge replies that contain an *anchored* grade are parsed:
previously such replies could be mis-parsed as the first letter appearing in the
judge's prose (often wrong); now the anchored grade wins. Replies with a single
letter, or with no conflicting prose letter, are parsed exactly as before, so
only previously-wrong results change — in the correct direction. `accuracy`,
`accuracy_given_attempted`, and `not_attempted_count` keep their exact
historical semantics; `judge_error_count` is a new, purely additive field.

## Out of scope

- Connector-less verb forms ("I grade A") are deliberately not covered and
  continue to follow the legacy scan — adding them would reintroduce the
  qualifier false-positive the connector requirement exists to prevent.
- The same loose-scan logic is copy-pasted into `MedXpertQA.py`,
  `medmcqa.py`, `supergpqa/supergpqa.py`, and `atlas/evaluation.py` (each with
  its own `_generic_llmjudge_postprocess` / `get_final_results`). This PR keeps
  the diff focused on the canonical `generic.py`; a follow-up could apply the
  same anchored-extraction pattern to the copies.
