### PR TITLE
docs: fix typos in gaokao_math and hellobench dataset READMEs

### DIFF
--- a/opencompass/configs/datasets/gaokao_math/README.md
+++ b/opencompass/configs/datasets/gaokao_math/README.md
@@ -63,7 +63,7 @@ gaokao_math_eval_cfg = dict(
 ...
 
 ```
-We recommand `Qwen2.5-72B-Instruct` model for evaluation.
+We recommend `Qwen2.5-72B-Instruct` model for evaluation.
 
 
 ### 3. Set Extractor model and run the evaluation

--- a/opencompass/configs/datasets/subjective/hellobench/README.md
+++ b/opencompass/configs/datasets/subjective/hellobench/README.md
@@ -1,8 +1,8 @@
 # Guideline for evaluating HelloBench on Diverse LLMs
 
-HelloBench is a comprehenvise, in-the-wild, and open-ended benchmark to evaluate LLMs' performance in generating long text. More details could be found in [🌐Github Repo](https://github.com/Quehry/HelloBench) and [📖Paper](https://arxiv.org/abs/2409.16191).
+HelloBench is a comprehensive, in-the-wild, and open-ended benchmark to evaluate LLMs' performance in generating long text. More details could be found in [🌐Github Repo](https://github.com/Quehry/HelloBench) and [📖Paper](https://arxiv.org/abs/2409.16191).
 
-## Detailed instructions to evalute HelloBench in Opencompass
+## Detailed instructions to evaluate HelloBench in Opencompass
 
 1. Git clone Opencompass
 


### PR DESCRIPTION
## Motivation

Three spelling errors in dataset READMEs. These files sit under `opencompass/configs/`, which is excluded from the `codespell` pre-commit hook, so typos in this tree are not caught automatically.

## Modification

- `opencompass/configs/datasets/gaokao_math/README.md` — `We recommand` → `We recommend`
- `opencompass/configs/datasets/subjective/hellobench/README.md` — `comprehenvise` → `comprehensive`, and `Detailed instructions to evalute` → `evaluate` in a heading

Documentation only. No code, config, or dataset behaviour is affected.

## BC-breaking (Optional)

No.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues. (`codespell` and `mdformat` with the repo's configured plugins both run clean on the two touched files; `mdformat` produces no reformatting.)
- [x] Bug fixes are fully covered by unit tests — N/A, documentation only.
- [x] The modification is covered by complete unit tests — N/A, documentation only.
- [x] The documentation has been modified accordingly.
