### PR TITLE
[Fix] Restore missing comma in first_option_postprocess answer patterns

### DIFF
--- a/opencompass/utils/text_postprocessors.py
+++ b/opencompass/utils/text_postprocessors.py
@@ -89,7 +89,7 @@ def first_option_postprocess(text: str, options: str, cushion=True) -> str:
         f'答案为\s*([{options}])',
         f'答案选\s*([{options}])',
         f'选择?\s*([{options}])',
-        f'故选?\s*([{options}])'
+        f'故选?\s*([{options}])',
         f'只有选?项?\s?([{options}])\s?是?对',
         f'只有选?项?\s?([{options}])\s?是?错',
         f'只有选?项?\s?([{options}])\s?不?正确',

--- a/tests/utils/test_text_postprocessors.py
+++ b/tests/utils/test_text_postprocessors.py
@@ -39,6 +39,21 @@ class TestTextPostprocessors(unittest.TestCase):
         text = '答案是 B'
         self.assertEqual(tp.first_option_postprocess(text, 'ABCD'), 'B')
 
+    def test_first_option_postprocess_merged_pattern_regression(self):
+        # Regression: a missing trailing comma implicitly concatenated the
+        # '故选X' pattern with the '只有选项X是对' pattern into a single 2-group
+        # regex, so the '只有选项X是对' extraction was destroyed. cushion=False
+        # disables the loose fallback, so a broken pattern surfaces as ''
+        # instead of the real answer (with cushion it returns a distractor).
+        self.assertEqual(
+            tp.first_option_postprocess('题目提到A和B，但只有选项B是对的',
+                                        'ABCD',
+                                        cushion=False), 'B')
+        self.assertEqual(
+            tp.first_option_postprocess('排除A、D后，只有选项C是对',
+                                        'ABCD',
+                                        cushion=False), 'C')
+
     def test_last_option_postprocess(self):
         text = 'A then C then B'
         self.assertEqual(tp.last_option_postprocess(text, 'ABC'), 'B')


### PR DESCRIPTION
## Motivation

`first_option_postprocess` (`opencompass/utils/text_postprocessors.py`) builds its answer-extraction regexes as a list of f-strings. One entry is missing a trailing comma:

```python
        f'选择?\s*([{options}])',
        f'故选?\s*([{options}])'          # <-- missing comma
        f'只有选?项?\s?([{options}])\s?是?对',
```

Python **implicit string concatenation** fuses those two lines into a single 2-group regex:

```
故选?\s*([ABCD])只有选?项?\s?([ABCD])\s?是?对
```

which requires `故选X` and `只有选项Y是对` to appear back-to-back — so the intended **`只有选项X是对`** ("only option X is correct") pattern is destroyed. Extraction then falls through to the loose `([ABCD])` cushion, which grabs the first option letter appearing anywhere in the reasoning (typically a distractor), or returns `''` when `cushion=False`. Either way the prediction is silently mis-scored.

`first_option_postprocess` is referenced by ~100 dataset configs (ceval, cmmlu, agieval, SIQA, mathbench, and custom multiple-choice), so the corruption is broad rather than niche.

## Modification

- Add the missing comma so both `故选X` and `只有选项X是对` are restored as standalone patterns (one-character change; no patterns added or reordered).
- Add a regression test in `tests/utils/test_text_postprocessors.py` for the `只有选项X是对` case (fails before the fix — returns `''` with `cushion=False` / a distractor with cushion — and passes after).

## Verification

Ran `first_option_postprocess` on the fixed module:

| input (options `ABCD`) | before | after |
|---|---|---|
| `题目提到A和B，但只有选项B是对的` | `''` / `A` | `B` |
| `排除A、D后，只有选项C是对` | `''` / `A` | `C` |
| `答案是 B` (existing) | `B` | `B` |

`flake8` clean on the changed files.