### PR TITLE
[Fix] Improve PubMedQA LLM-judge verdict robustness

### DIFF
--- a/docs/en/advanced_guides/llm_judge.md
+++ b/docs/en/advanced_guides/llm_judge.md
@@ -232,7 +232,23 @@ The GenericLLMEvaluator is designed to use an LLM as a judge for evaluating mode
 3. Customizable evaluation criteria through prompt engineering
 4. Post-processing of judge outputs to extract structured evaluations
 
-**Important Note**: The current generic version of the judge template only supports outputs in the format of "A" (correct) or "B" (incorrect), and does not support other output formats (like "CORRECT" or "INCORRECT"). This is because the post-processing function `generic_llmjudge_postprocess` is specifically designed to parse this format.
+**Important Note**: `generic_llmjudge_postprocess` uses `A` (correct) and
+`B` (incorrect) by default. Its `true_tag` and `false_tag` arguments allow
+other distinct verdict tags. For example, configure a judge to return `X` for
+correct and `Y` for incorrect with:
+
+```python
+dict_postprocessor=dict(
+    type=generic_llmjudge_postprocess,
+    true_tag='X',
+    false_tag='Y',
+)
+```
+
+The judge prompt should instruct the model to return exactly the configured
+tags. For multiple-choice tasks whose option labels overlap with the default
+`A`/`B` verdict labels, consider using disjoint tags such as `X`/`Y` to reduce
+ambiguity.
 
 The evaluator works by:
 

--- a/opencompass/configs/datasets/PubMedQA/PubMedQA_llmjudge_gen_f00302.py
+++ b/opencompass/configs/datasets/PubMedQA/PubMedQA_llmjudge_gen_f00302.py
@@ -16,22 +16,27 @@ Options:\n
 """.strip()
 
 GRADER_TEMPLATE = """
-    Please as a grading expert, judge whether the final answers given by the candidates below are consistent with the standard answers, that is, whether the candidates answered correctly. 
-    
-    Here are some evaluation criteria:
-    1. Please refer to the given standard answer. You don't need to re-generate the answer to the question because the standard answer has been given. You only need to judge whether the candidate's answer is consistent with the standard answer according to the form of the question. Don't try to answer the original question. You can assume that the standard answer is definitely correct.
-    2. Because the candidate's answer may be different from the standard answer in the form of expression, before making a judgment, please understand the question and the standard answer first, and then judge whether the candidate's answer is correct, but be careful not to try to answer the original question.
-    3. Some answers may contain multiple items, such as multiple-choice questions, multiple-select questions, fill-in-the-blank questions, etc. As long as the answer is the same as the standard answer, it is enough. For multiple-select questions and multiple-blank fill-in-the-blank questions, the candidate needs to answer all the corresponding options or blanks correctly to be considered correct.
-    4. Some answers may be expressed in different ways, such as some answers may be a mathematical expression, some answers may be a textual description, as long as the meaning expressed is the same. And some formulas are expressed in different ways, but they are equivalent and correct.
-    Please judge whether the following answers are consistent with the standard answer based on the above criteria. Grade the predicted answer of this new question as one of:
-    A: CORRECT 
-    B: INCORRECT
-    Just return the letters "A" or "B", with no text around it.
-    Here is your task. Simply reply with either CORRECT, INCORRECT. Don't apologize or correct yourself if there was a mistake; we are just trying to grade the answer.
-    <Original Question Begin>: {question}\n {choices} \n<Original Question End>\n\n
-    <Gold Target Begin>: \n{label}\n<Gold Target End>\n\n
-    <Predicted Answer Begin>: \n{prediction}\n<Predicted End>\n\n
-    Judging the correctness of candidates' answers:
+Please judge whether the candidate answer is consistent with the gold answer.
+The gold answer is correct. Do not answer the original multiple-choice question.
+
+Return exactly one letter and no other text:
+X: CORRECT
+Y: INCORRECT
+
+<Original Question Begin>:
+{question}
+{choices}
+<Original Question End>
+
+<Gold Target Begin>:
+{label}
+<Gold Target End>
+
+<Predicted Answer Begin>:
+{prediction}
+<Predicted Answer End>
+
+Verdict:
 """.strip()
 
 PubMedQA_datasets = []
@@ -78,7 +83,11 @@ PubMedQA_eval_cfg = dict(
             reader_cfg=PubMedQA_reader_cfg,
         ),
         judge_cfg=dict(),
-        dict_postprocessor=dict(type=generic_llmjudge_postprocess),
+        dict_postprocessor=dict(
+            type=generic_llmjudge_postprocess,
+            true_tag='X',
+            false_tag='Y',
+        ),
     ),
 )
 

--- a/tests/datasets/test_generic.py
+++ b/tests/datasets/test_generic.py
@@ -1,0 +1,28 @@
+from opencompass.datasets.generic import generic_llmjudge_postprocess
+
+
+def test_generic_llmjudge_postprocess_custom_tags():
+    output = {
+        '0': {
+            'prediction': 'X',
+            'gold': 'B',
+        },
+        '1': {
+            'prediction': 'Y',
+            'gold': 'C',
+        },
+    }
+
+    scores = generic_llmjudge_postprocess(
+        output,
+        output_path='unused.json',
+        true_tag='X',
+        false_tag='Y',
+    )
+
+    assert scores['accuracy'] == 50
+    assert scores['accuracy_given_attempted'] == 50
+    assert scores['attempted_ratio'] == 100
+    assert scores['correct_count'] == 1
+    assert scores['incorrect_count'] == 1
+    assert scores['not_attempted_count'] == 0


### PR DESCRIPTION
## Motivation

While reproducing PubMedQA, I found two issues in `opencompass/configs/datasets/PubMedQA/PubMedQA_llmjudge_gen_f00302.py`, specifically in `GRADER_TEMPLATE`.

First, the template gives conflicting output instructions:

- `A: CORRECT`, `B: INCORRECT`
- "Just return the letters `A` or `B`"
- later, "Simply reply with either `CORRECT`, `INCORRECT`"

The judge therefore receives two incompatible output formats.

Second, PubMedQA is a multiple-choice task whose original answer labels are `A/B/C`. The same letters are visible in the question options, gold target, and candidate answer (for example, `ANSWER: B`), while `A/B` are also used as judge verdict labels. This label overlap can make the intended meaning of a generated `A` or `B` ambiguous.

For example, when the gold answer is `B` and the candidate prediction is also `B`, the correct judge verdict is `A` (`CORRECT`), but `B` is simultaneously the original task answer label. The same risk may exist in other multiple-choice benchmarks that reuse task-option labels as judge verdict labels; this PR is intentionally limited to the reproduced PubMedQA case.

## Modification

- Use `X` for correct and `Y` for incorrect in the PubMedQA judge prompt.
- Configure `generic_llmjudge_postprocess` with `true_tag='X'` and `false_tag='Y'`.
- Document configurable judge verdict tags.
- Add a unit test for custom X/Y tags.

## Validation

- Verified custom X/Y post-processing and PubMedQA config loading.
- Controlled experiments indicate that removing the conflicting instruction improves robustness; the label-overlap effect is model-dependent.

No changes are made to `GenericLLMEvaluator` or the generic parser.