### PR TITLE
docs: fix configs links after v0.4.0 migration

### DIFF
--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -186,7 +186,7 @@ datasets = [*siqa_datasets, *winograd_datasets]       # The final config needs t
 
 Dataset configurations are typically of two types: 'ppl' and 'gen', indicating the evaluation method used. Where `ppl` means discriminative evaluation and `gen` means generative evaluation.
 
-Moreover, [configs/datasets/collections](https://github.com/open-compass/opencompass/blob/main/configs/datasets/collections) houses various dataset collections, making it convenient for comprehensive evaluations. OpenCompass often uses [`base_medium.py`](/configs/datasets/collections/base_medium.py) for full-scale model testing. To replicate results, simply import that file, for example:
+Moreover, [configs/datasets/collections](https://github.com/open-compass/opencompass/blob/main/opencompass/configs/datasets/collections) houses various dataset collections, making it convenient for comprehensive evaluations. OpenCompass often uses [`base_medium.py`](https://github.com/open-compass/opencompass/blob/main/opencompass/configs/datasets/collections/base_medium.py) for full-scale model testing. To replicate results, simply import that file, for example:
 
 ```bash
 python run.py --models hf_llama_7b --datasets base_medium

--- a/docs/zh_cn/get_started/quick_start.md
+++ b/docs/zh_cn/get_started/quick_start.md
@@ -205,7 +205,7 @@ datasets = gsm8k_datasets + math_datasets       # 最终的配置需要包含所
 
 数据集配置通常有两种类型：`ppl` 和 `gen`，分别指示使用的评估方法。其中 `ppl` 表示辨别性评估，`gen` 表示生成性评估。对话模型仅使用 `gen` 生成式评估。
 
-此外，[configs/datasets/collections](https://github.com/open-compass/opencompass/blob/main/configs/datasets/collections) 收录了各种数据集集合，方便进行综合评估。OpenCompass 通常使用 [`chat_OC15.py`](https://github.com/open-compass/opencompass/blob/main/configs/dataset_collections/chat_OC15.py) 进行全面的模型测试。要复制结果，只需导入该文件，例如：
+此外，[configs/datasets/collections](https://github.com/open-compass/opencompass/blob/main/opencompass/configs/datasets/collections) 收录了各种数据集集合，方便进行综合评估。OpenCompass 通常使用 [`chat_OC15.py`](https://github.com/open-compass/opencompass/blob/main/opencompass/configs/dataset_collections/chat_OC15.py) 进行全面的模型测试。要复制结果，只需导入该文件，例如：
 
 ```bash
 python run.py --models hf_internlm2_chat_1_8b --datasets chat_OC15 --debug


### PR DESCRIPTION
## Motivation
After the v0.4.0 migration (see the Breaking Change notice in README), dataset/model configs were moved from ./configs to the opencompass package. The quick start docs still link to the old paths, which now 404 on GitHub.

## Modification
- docs/en/get_started/quick_start.md: fix configs/datasets/collections and base_medium.py links to opencompass/configs/...
- docs/zh_cn/get_started/quick_start.md: fix configs/datasets/collections and chat_OC15.py links to opencompass/configs/...

## Verification
- Confirmed the new target files exist in the repository (opencompass/configs/datasets/collections/base_medium.py, opencompass/configs/dataset_collections/chat_OC15.py).
- Verified the updated GitHub links resolve (HTTP 200).