### PR TITLE
docs: fix English version link in testing guide

### DIFF
--- a/tests/TESTING_GUIDE_zh-CN.md
+++ b/tests/TESTING_GUIDE_zh-CN.md
@@ -2,7 +2,7 @@
 
 本文档提供了为 `opencompass/datasets/` 下的数据集实现添加单元测试的指引和规范。
 
-> **English Version**: See [TESTING_GUIDE_EN.md](./TESTING_GUIDE_EN.md) for the English version of this guide.
+> **English Version**: See [TESTING_GUIDE.md](./TESTING_GUIDE.md) for the English version of this guide.
 
 ## 目录结构
 


### PR DESCRIPTION
## Motivation
The Chinese testing guide links to TESTING_GUIDE_EN.md for the English version, but the actual English file in the repo is named TESTING_GUIDE.md. The link currently 404s.

## Modification
- tests/TESTING_GUIDE_zh-CN.md: point the English version link to TESTING_GUIDE.md.

## Verification
- Confirmed tests/TESTING_GUIDE.md exists.
- Updated relative link resolves correctly.