### PR TITLE
docs: correct three docstring defaults that disagree with the signatures

### DIFF
--- a/opencompass/datasets/SciReasoner/Mol_Instructions/normalized_SW_score.py
+++ b/opencompass/datasets/SciReasoner/Mol_Instructions/normalized_SW_score.py
@@ -11,7 +11,7 @@ def normalized_smith_waterman(seq1,
 
     Args:
         seq1, seq2 (str): Protein sequences (uppercase letters)
-        matrix_name (str): Name of substitution matrix (default: BLOSUM62)
+        matrix_name (str): Name of substitution matrix (default: BLOSUM45)
         open_gap (float): Gap opening penalty
         extend_gap (float): Gap extension penalty
 

--- a/opencompass/models/turbomind_api.py
+++ b/opencompass/models/turbomind_api.py
@@ -100,7 +100,7 @@ class TurboMindAPIModel(BaseModel):
             temperature (float): What sampling temperature to use,
                 between 0 and 2. Higher values like 0.8 will make the output
                 more random, while lower values like 0.2 will make it more
-                focused and deterministic. Defaults to 0.7.
+                focused and deterministic. Defaults to 1.0.
             end_str (str, optional): Whether to trim generated strings
                 with end_str if the model has special ending strings
                 that are not handled well.

--- a/opencompass/openicl/icl_evaluator/code_evaluator.py
+++ b/opencompass/openicl/icl_evaluator/code_evaluator.py
@@ -32,7 +32,7 @@ class CodeEvaluator(BaseEvaluator):
         Args:
             language (str): Programming language of the code to evaluate.
             ip_address (str, optional): IP address of the evaluation service. Defaults to 'localhost'.
-            retry (int, optional): Number of retry attempts for failed connections. Defaults to 3.
+            retry (int, optional): Number of retry attempts for failed connections. Defaults to 5.
         """
         self.language = language
         self.retry = retry


### PR DESCRIPTION
## Motivation

Three docstrings in the repository state parameter defaults that the function signatures do not have. A reader trusting the docstring would expect different behaviour than the code produces. The goal is to make those three lines agree with the signatures they describe.

## Modification

| File | Parameter | Docstring said | Signature has |
|---|---|---|---|
| `opencompass/openicl/icl_evaluator/code_evaluator.py` | `retry` | Defaults to 3 | `retry: int = 5` |
| `opencompass/models/turbomind_api.py` | `temperature` | Defaults to 0.7 | `temperature: float = 1.0` |
| `opencompass/datasets/SciReasoner/Mol_Instructions/normalized_SW_score.py` | `matrix_name` | default: BLOSUM62 | `matrix_name='BLOSUM45'` |

The `matrix_name` one is the most consequential of the three: BLOSUM62 and BLOSUM45 are different substitution matrices, so a reader trusting the docstring would expect different alignment scores than the function actually produces.

Docstring text only — three lines, no behaviour changes, and no other issues in these files were touched.

### Checked and left alone

While looking for this class of drift I also examined four other candidates and found the docstrings correct:

- `opencompass/utils/network.py` — `host` reads `(default: Google DNS "8.8.8.8")`, which matches `host: str = '8.8.8.8'`.
- `opencompass/summarizers/llm_compression.py` and `opencompass/summarizers/subjective/compass_arena_bradley_terry.py` — `time_str` reads "Defaults to `datetime.now().strftime('%Y%m%d_%H%M%S')`", wrapped across two lines, matching the signature exactly.
- `opencompass/openicl/icl_evaluator/lm_evaluator.py` — `seed` states no default at all, so there is nothing to disagree with. Its signature default is `666`, which is undocumented, but that is a gap rather than a contradiction and is left for a separate change.

One related thing I noticed but did not touch, since it is not a default: `turbomind_api.py` documents `end_str` in the `Args:` block of `generate`, but `end_str` is not a parameter of that method — it is read from `self.end_str`. Happy to fix that here or separately if you would like.

## BC-breaking (Optional)

No. The change is docstring text only; no signature, default, or runtime behaviour is altered, so nothing downstream can observe it.

## Use cases (Optional)

Not a new feature.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.

Notes on the boxes left unchecked, so you are not left guessing:

- *Unit tests.* The diff is three lines of docstring text. There is no behaviour to assert on, so no test was added and none is meaningful here.
- *Downstream testing.* The modification has no potential influence on downstream projects, for the reason given under BC-breaking, so the condition attached to that item does not arise.

On linting: all three files compile and pass `ruff check --select E9,F`. The three pre-existing extraneous-f-prefix warnings that `ruff --isolated` reports in these files are present on `main` as well and are unrelated to this change.

---

On the CLA checklist item: I could not find a CLA document, bot, or status check in this repository, and recent PRs do not appear to have gone through one. All commits here are authored and committed as `eirik@ecodeco.no` and are GPG-verified. If there is a CLA process I have missed, point me to it and I will sign it.
