### PR TITLE
Skip token type ids in Hugging Face backend

### DIFF
--- a/opencompass/models/huggingface_above_v4_33.py
+++ b/opencompass/models/huggingface_above_v4_33.py
@@ -296,6 +296,7 @@ class HuggingFacewithChatTemplate(BaseModel):
             padding=True,
             truncation=True,
             add_special_tokens=True,
+            return_token_type_ids=False,
             max_length=self.max_seq_len,
         )
 
@@ -462,6 +463,7 @@ class HuggingFacewithChatTemplate(BaseModel):
             padding=True,
             truncation=True,
             add_special_tokens=True,
+            return_token_type_ids=False,
             max_length=self.max_seq_len
         )
         if self.fastchat_template:
@@ -581,6 +583,7 @@ class HuggingFaceBaseModel(HuggingFacewithChatTemplate):
             padding=True,
             truncation=True,
             add_special_tokens=True,
+            return_token_type_ids=False,
             max_length=self.max_seq_len
         )
 
@@ -643,6 +646,7 @@ class HuggingFaceBaseModel(HuggingFacewithChatTemplate):
             padding=True,
             truncation=True,
             add_special_tokens=True,
+            return_token_type_ids=False,
             max_length=self.max_seq_len
         )
 

--- a/tests/models/test_huggingface_above_v4_33.py
+++ b/tests/models/test_huggingface_above_v4_33.py
@@ -126,6 +126,9 @@ class TestHuggingFacewithChatTemplate(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0], 'Generated response')
         mock_model.generate.assert_called_once()
+        self.assertFalse(
+            mock_tokenizer.batch_encode_plus.call_args.kwargs[
+                'return_token_type_ids'])
 
     @patch('transformers.AutoTokenizer')
     @patch(
@@ -243,6 +246,9 @@ class TestHuggingFaceBaseModel(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0], 'Generated response')
         mock_model.generate.assert_called_once()
+        self.assertFalse(
+            mock_tokenizer.batch_encode_plus.call_args.kwargs[
+                'return_token_type_ids'])
 
     @patch('transformers.AutoTokenizer')
     @patch(

--- a/tests/models/test_huggingface_token_type_ids.py
+++ b/tests/models/test_huggingface_token_type_ids.py
@@ -28,6 +28,7 @@ class TestPPLTokenization(unittest.TestCase):
         model = HuggingFaceBaseModel.__new__(HuggingFaceBaseModel)
         model.tokenizer = _RecordingTokenizer()
         model.max_seq_len = 32
+        model.drop_middle = False
 
         with self.assertRaises(_StopTokenization):
             model.get_ppl(['hello'])

--- a/tests/models/test_huggingface_token_type_ids.py
+++ b/tests/models/test_huggingface_token_type_ids.py
@@ -1,0 +1,50 @@
+"""Tests for Hugging Face tokenizer outputs used by PPL paths."""
+
+import unittest
+
+from opencompass.models.huggingface_above_v4_33 import (
+    HuggingFaceBaseModel, HuggingFacewithChatTemplate)
+
+
+class _StopTokenization(Exception):
+    pass
+
+
+class _RecordingTokenizer:
+    pad_token = '<pad>'
+    pad_token_id = 0
+
+    def __init__(self):
+        self.kwargs = None
+
+    def batch_encode_plus(self, *args, **kwargs):
+        self.kwargs = kwargs
+        raise _StopTokenization
+
+
+class TestPPLTokenization(unittest.TestCase):
+
+    def test_base_model_get_ppl_skips_token_type_ids(self):
+        model = HuggingFaceBaseModel.__new__(HuggingFaceBaseModel)
+        model.tokenizer = _RecordingTokenizer()
+        model.max_seq_len = 32
+
+        with self.assertRaises(_StopTokenization):
+            model.get_ppl(['hello'])
+
+        self.assertFalse(model.tokenizer.kwargs['return_token_type_ids'])
+
+    def test_chat_template_get_ppl_tokenwise_skips_token_type_ids(self):
+        model = HuggingFacewithChatTemplate.__new__(
+            HuggingFacewithChatTemplate)
+        model.tokenizer = _RecordingTokenizer()
+        model.max_seq_len = 32
+
+        with self.assertRaises(_StopTokenization):
+            model.get_ppl_tokenwise(['hello'], [[(0, 1, 1)]])
+
+        self.assertFalse(model.tokenizer.kwargs['return_token_type_ids'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Motivation

Some `PreTrainedTokenizerFast` tokenizers return `token_type_ids`. Hugging Face generation rejects this key for models that do not accept it, causing evaluation to fail.

## Modification

Disable `token_type_ids` in Hugging Face generation and perplexity tokenization paths, with regression tests for both paths.

Fixes #1533

## Checklist

- [x] Bug fix covered by unit tests
- [x] Lint checks passed
- [x] No documentation changes required