### PR TITLE
docs: clarify prompt version in summaries

### DIFF
--- a/docs/en/user_guides/summarizer.md
+++ b/docs/en/user_guides/summarizer.md
@@ -39,7 +39,7 @@ The summarizer tries to read the evaluation scores from the `{work_dir}/results/
 In addition, the output consists of multiple columns:
 
 - The `dataset` column corresponds to the `summarizer.dataset_abbrs` configuration.
-- The `version` column is the hash value of the dataset, which considers the dataset's evaluation method, prompt words, output length limit, etc. Users can verify whether two evaluation results are comparable using this column.
+- The `version` column is the first six characters of the SHA-256 hash of the dataset's `infer_cfg` (the prompt hash). It identifies inference settings such as the evaluation method, prompt template, and output length limit. It is not the suffix of the dataset config filename and does not represent the dataset or data release version. Consequently, the two values need not match. Use this column to check whether results were produced with comparable inference and prompt settings.
 - The `metric` column indicates the evaluation method of this metric. For specific details, [metrics](./metrics.md).
 - The `mode` column indicates how the inference result is obtained. Possible values are `ppl` / `gen`. For items in `summarizer.summary_groups`, if the methods of obtaining `subsets` are consistent, its value will be the same as subsets, otherwise it will be `mixed`.
 - The subsequent columns represent different models.

--- a/docs/zh_cn/user_guides/summarizer.md
+++ b/docs/zh_cn/user_guides/summarizer.md
@@ -39,7 +39,7 @@ summarizer 会以 config 中的 `models`, `datasets` 为全集，去尝试读取
 此外，输出结果是有多列的：
 
 - `dataset` 列与 `summarizer.dataset_abbrs` 配置一一对应
-- `version` 列是这个数据集的 hash 值，该 hash 值会考虑该数据集模板的评测方式、提示词、输出长度限制等信息。用户可通过该列信息确认两份评测结果是否可比
+- `version` 列是数据集 `infer_cfg` 的 SHA-256 哈希（即 prompt hash）的前 6 位，用于标识评测方式、提示词模板、输出长度限制等推理配置。它既不是数据集配置文件名的后缀，也不表示数据集或数据发布版本，因此二者无需一致。用户可通过该列确认两份结果的推理配置和提示词设置是否可比
 - `metric` 列是指这个指标的评测方式，具体说明见 [metrics](./metrics.md)
 - `mode` 列是指这个推理结果的获取方式，可能的值有 `ppl` / `gen`。对于 `summarizer.summary_groups` 的项，若被 `subsets` 的获取方式都一致，则其值也跟 `subsets` 一致，否则即为 `mixed`
 - 其后若干列，一列代表一个模型

--- a/tests/summarizers/test_default.py
+++ b/tests/summarizers/test_default.py
@@ -56,6 +56,45 @@ class TestDefaultSummarizer(unittest.TestCase):
             # Should log a warning about prompt_db being deprecated
             mock_log.warning.assert_called()
 
+    def test_summary_version_is_prompt_hash_prefix(self):
+        """Test the version column keeps reporting the prompt hash prefix."""
+        dataset = ConfigDict({
+            'abbr': 'race-middle_5831a0',
+            'version': 'data-v2',
+            'infer_cfg': {
+                'retriever': {
+                    'type': 'ZeroRetriever'
+                },
+                'inferencer': {
+                    'type': 'GenInferencer'
+                },
+                'prompt_template': {
+                    'type': 'PromptTemplate',
+                    'template': 'Question: {question}'
+                }
+            }
+        })
+        self.config.datasets = [dataset]
+        summarizer = DefaultSummarizer(config=self.config)
+
+        table = summarizer._format_table(
+            parsed_results={
+                'test_model': {
+                    'race-middle_5831a0': {
+                        'accuracy': 88.5
+                    }
+                }
+            },
+            dataset_metrics={'race-middle_5831a0': ['accuracy']},
+            dataset_eval_mode={'race-middle_5831a0': 'gen'})
+
+        self.assertEqual(
+            table,
+            [['dataset', 'version', 'metric', 'mode', 'test_model'],
+             ['race-middle_5831a0', '6b938f', 'accuracy', 'gen', '88.50']])
+        self.assertNotEqual(table[1][1], '5831a0')
+        self.assertNotEqual(table[1][1], dataset.version)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Motivation
The `version` column in summary output can be mistaken for a dataset version or for the hash suffix in a dataset config filename.

## Changes
- clarify in English and Chinese docs that the value is the first six characters of the SHA-256 hash of `infer_cfg`
- state that it is not a dataset release version or config filename suffix
- add a regression test that locks the prompt-hash source while preserving the existing table format

## Verification
- focused summarizer tests: 5 passed
- flake8, isort, yapf, codespell, and mdformat: passed
- `git diff --check`: passed

Related to #760.