### PR TITLE
[Fix] Follow redirects when a custom httpx client is supplied to the OpenAI SDK

### DIFF
--- a/opencompass/models/openai_api.py
+++ b/opencompass/models/openai_api.py
@@ -802,6 +802,12 @@ class OpenAISDK(OpenAI):
         # Create fresh client with current key
         http_client_cfg = self.http_client_cfg.copy()
         set_proxy_cfg(http_client_cfg, self.proxy_url)
+        # httpx defaults follow_redirects to False, and openai-python only
+        # applies its own follow_redirects=True when it builds the client
+        # itself -- supplying http_client bypasses that. Without this, any
+        # endpoint that answers with a redirect (common for hosted gateways)
+        # surfaces the raw redirect response as an API error.
+        http_client_cfg.setdefault('follow_redirects', True)
         limits = httpx.Limits(max_keepalive_connections=2048,
                               max_connections=4096)
         http_client = httpx.Client(**http_client_cfg,
@@ -1024,6 +1030,9 @@ class OpenAISDKRollout(OpenAI):
                     'http://': self.proxy_url,
                     'https://': self.proxy_url,
                 }
+            # See the note in OpenAISDK._create_fresh_client: a supplied
+            # http_client loses openai-python's follow_redirects=True default.
+            http_client_cfg.setdefault('follow_redirects', True)
 
         self.openai_client = OpenAI(
             base_url=self.openai_api_base,


### PR DESCRIPTION
## Problem

`OpenAISDK` and `OpenAISDKRollout` build their own `httpx.Client` and hand it to `OpenAI(http_client=...)`. That silently disables redirect following:

- `httpx.Client()` defaults `follow_redirects=False`.
- openai-python only applies its own `follow_redirects=True` when **it** constructs the client — `_base_client.py` does `self._client = http_client or SyncHttpxClientWrapper(...)`, and only that wrapper calls `kwargs.setdefault("follow_redirects", True)`.

So supplying `http_client` bypasses the SDK default, and any endpoint that answers with a redirect fails. The failure is unhelpful: the raw redirect response surfaces as an `APIStatusError` containing HTML, not a connection error, so it looks like a broken endpoint rather than a client setting.

This affects any OpenAI-compatible endpoint that redirects — hosted gateways commonly do — not one specific provider.

## Fix

`http_client_cfg.setdefault('follow_redirects', True)` at both construction sites, so the SDK's own default is preserved. Because it's `setdefault`, a user who explicitly passes `http_client_cfg=dict(follow_redirects=False)` still wins.

9 added lines, 6 of which are the explanatory comments.

## Reproduction

Against a real endpoint that answers `307`, running the exact constructor from `_create_fresh_client`:

```
before (http_client_cfg = {})      APIStatusError: redirect not followed
after  (setdefault applied)        OK -> openai/gpt-oss-120b
user override preserved            follow_redirects=False (not clobbered)
```

For contrast, the same request through a client that openai-python builds itself succeeds — which is what makes this specific to the supplied-client path.

## Notes

- `OpenAISDKRollout` passes `None` when `http_client_cfg` is empty, so the SDK builds its own client and that path was already correct; the `setdefault` only applies where a client is actually constructed.
- The legacy `OpenAI` class uses `requests`, which follows redirects already, so it is unaffected.
- There is a user-side workaround today (`http_client_cfg=dict(follow_redirects=True)` in the model config), but it is undocumented and the failure mode gives no hint that it's needed.

Disclosure: I work on The Grid, an OpenAI-compatible provider whose endpoint redirects — that's how I hit this. The fix isn't provider-specific and I've deliberately not added any Grid config in this PR.
