### PR TITLE
Replace removed tokenizer.encode_plus in DatasetEncoder

### DIFF
--- a/opencompass/openicl/icl_dataset_reader.py
+++ b/opencompass/openicl/icl_dataset_reader.py
@@ -266,10 +266,11 @@ class DatasetEncoder(torch.utils.data.Dataset):
 
     def init_dataset(self):
         for idx, data in enumerate(self.datalist):
-            tokenized_data = self.tokenizer.encode_plus(data,
-                                                        truncation=True,
-                                                        return_tensors='pt',
-                                                        verbose=False)
+            # (tokenizer.__call__ instead of encode_plus, which was removed in transformers 5.x)
+            tokenized_data = self.tokenizer(data,
+                                            truncation=True,
+                                            return_tensors='pt',
+                                            verbose=False)
             self.encode_dataset.append({
                 'input_ids':
                 tokenized_data.input_ids[0],


### PR DESCRIPTION
Fixes #2635

`encode_plus` was removed in transformers 5.x, so any run using TopkRetriever (which encodes few-shot examples through `DatasetEncoder`) crashes:

```
AttributeError: Qwen2Tokenizer has no attribute encode_plus
```

Same class of breakage as #2573. The tokenizer call API is a drop-in replacement here — for a single string it returns the same `[1, L]` `input_ids` / `attention_mask` tensors, and `verbose` is still accepted.

Verified with a real Qwen2Tokenizer on transformers 5.16: the old call raises the AttributeError above, the direct call produces the same per-sample `[L]` tensors `DatasetEncoder` stores.
